### PR TITLE
デザイントークン拡張と共通コンポーネント雛形を追加 (#10)

### DIFF
--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -1,0 +1,228 @@
+# またたび計算機 デザイントークン運用ガイド
+
+## 1. このドキュメントの目的
+
+- 各 UI 実装 PR でクラス名選択にブレを出さないための一次情報源。
+- カラー（Issue #7）/ 余白・角丸・シャドウ・タイポ補強（Issue #10）の運用ルールをまとめる。
+- 暫定値 / 確定値の境界を示す。
+
+ソース・オブ・トゥルース:
+
+- 値の物理定義: `tailwind.config.ts` の `theme.extend`
+- グローバル base スタイル: `src/app/globals.css` の `@layer base`
+- 雛形コンポーネント: `src/components/ui/`
+- ヘルパ: `src/lib/cn.ts`
+
+---
+
+## 2. カラー（Issue #7 で確定済み、再掲）
+
+ロール別 4 トークン + パレット名 4 トークン（同 HEX、用途別エイリアス）:
+
+| ロール | パレット名 | HEX | 主な用途 |
+|---|---|---|---|
+| `canvas` | `offwhite` | `#F8F6F2` | ページ背景 / カード背景 / Button 上のテキスト |
+| `ink` | `ash` | `#72665B` | 本文テキスト / 主要 UI のフォアグラウンド |
+| `line` | `greige` | `#BEB5AA` | 罫線 / 区切り（不透明度修飾と併用、例 `border-line/50`） |
+| `accent` | `misty` | `#9CAEB8` | CTA / リンク / フォーカスリング |
+
+設計方針:
+
+- HEX は `tailwind.config.ts` に直書きし、CSS 変数を挟まない（`getComputedStyle` を経由せず JS から色値を取得する場面で扱いを単純化するため）。
+- ライトモード固定。マスター設計書 §3.3 にダークモード指定はないため、`darkMode` / `prefers-color-scheme: dark` は意図的に持ち込まない。
+
+---
+
+## 3. 余白の運用ルール
+
+`tailwind.config.ts` の `theme.extend.spacing` に **追加しない**。Tailwind デフォルトスケール（4px 刻み）をそのまま使う。揃いはコードベース上の運用ルールで担保する。
+
+| 用途 | 推奨クラス | 数値 |
+|---|---|---|
+| セクション間（縦） | `space-y-6`（モバイル `space-y-4`） | 24px / 16px |
+| カード間（縦） | `gap-6`（モバイル `gap-4`） | 24px / 16px |
+| カード padding | `p-6`（モバイル `p-4`） | 24px / 16px |
+| カード内の見出しと本文 | `space-y-3` または `mb-3` | 12px |
+| インライン要素間（アイコン + テキスト） | `gap-2` または `gap-3` | 8px / 12px |
+| ヒーロー上下余白（ResultDashboard） | `py-12`（モバイル `py-8`） | 48px / 32px |
+| ページの左右マージン | `px-6`（モバイル `px-4`） | 24px / 16px |
+| 最大幅（ダッシュボード） | `max-w-[1024px]` | spec 確定値、任意値 |
+| 最大幅（グラフ） | `max-w-[960px]` | 同上 |
+| 最大幅（補助カード） | `max-w-[720px]` | 同上 |
+
+任意値（`max-w-[1024px]` 等）は Tailwind が自動生成するため `theme.extend` への登録は不要。後続実装で 3 箇所以上で同じ任意値を書くと判明した場合は、その時点でセマンティックキー化を別 Issue で検討する。
+
+---
+
+## 4. 角丸の用途マッピング
+
+`tailwind.config.ts` の `theme.extend.borderRadius` に **追加しない**。Tailwind デフォルトをそのまま使い、用途で揃える。
+
+| 用途 | 推奨クラス | 数値 | 理由 |
+|---|---|---|---|
+| ボタン / 入力フィールド | `rounded-md` | 6px | 業務系 UI の標準サイズ |
+| Tab / Pill 型ボタン | `rounded-full` | — | 切替系を視覚的に区別 |
+| カード（デフォルト） | `rounded-xl` | 12px | 「大人の余裕」 |
+| カード（大型 / ヒーロー） | `rounded-2xl` | 16px | ResultDashboard 主要カード等 |
+| バッジ / タグ | `rounded-full` | — | バッジは丸ピル型で統一 |
+| グラフのバー先端 | `rounded-sm` | 2px | Recharts `<Bar radius={[2,2,0,0]}>` |
+| 警告バナー | `rounded-xl` | 12px | カードと同じトーン |
+| モーダル / シート | `rounded-2xl` / `rounded-t-2xl`（モバイルボトムシート） | 16px | 必要発生時に追加 |
+
+雛形 `Card` のデフォルト角丸は `rounded-xl` で固定。`<Card variant="hero">` のような大型バリアントは本 Issue では実装せず、必要発生時に別 Issue で追加する。
+
+---
+
+## 5. シャドウの用途マッピング
+
+`theme.extend.boxShadow` に ink (`#72665B`) ベースの rgba を 3 種だけ追加。Tailwind デフォルト（`shadow-md` 等）の黒シャドウは canvas 上で濁って見えるため、原則使わない。
+
+| 用途 | 推奨クラス | 値 |
+|---|---|---|
+| カード（静止） | `shadow-card` | `0 1px 2px ..., 0 1px 3px ...`（ink 5% / 4%） |
+| カード（hover） | `hover:shadow-card-hover` | `0 4px 12px ..., 0 2px 4px ...`（ink 10% / 6%） |
+| モーダル / トースト / ドロップダウン | `shadow-floating` | `0 12px 24px -4px ...`（ink 12%） |
+| グラフ / 入力フィールド | shadow なし | border + 余白で表現 |
+| 警告バナー | shadow なし | border + 背景色で表現 |
+
+> 数値は暫定。実 UI が画面に並んだ際の見え方で再調整余地あり（§10 申し送り参照）。
+> Tailwind デフォルト（`shadow-sm` / `shadow-md` 等）は **原則使わない**。例外的に必要になった時点で本ドキュメントを更新する。
+
+---
+
+## 6. タイポグラフィ補強
+
+`fontSize` / `lineHeight` には何も追加しない。Tailwind デフォルトスケール（`text-xs`〜`text-9xl`）を使う。
+
+追加するのは `letterSpacing.warning` のみ:
+
+| キー | 値 | 用途 |
+|---|---|---|
+| `letterSpacing.warning` | `0.06em` | WarningBanner の英字見出し（例 `CRITICAL OPPORTUNITY LOSS`）。`docs/spec/warning-copy.md` の 0.05em〜0.08em の中央値 |
+
+ヒーロー数値の `clamp(2.5rem, 6vw, 4rem)` は ResultDashboard 内 1 箇所でしか使わない想定のため、実装側で `text-[clamp(2.5rem,6vw,4rem)]` などの任意値で個別に書く。2 箇所以上で再利用したくなった時点でトークン化を別 Issue で検討。
+
+---
+
+## 7. フォーカスリング
+
+a11y のベースラインとして 2 段構えで運用する。
+
+### 7.1 グローバル（`src/app/globals.css`）
+
+```css
+*:focus-visible {
+  outline: 2px solid #9caeb8;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+```
+
+`*:focus-visible` で **すべての要素** に accent 色 2px の outline を当てる。ネイティブ `outline` プロパティを使うことでレイアウト計算に影響しない。
+
+### 7.2 雛形コンポーネント側
+
+`Button` 等の主要インタラクティブ要素は `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` を付与し、`box-shadow` ベースの `ring` ユーティリティへ切り替える。リング色 / 太さ / オフセット色は `theme.extend.ringColor.DEFAULT` / `ringWidth.DEFAULT` / `ringOffsetColor.DEFAULT` で集約しているため、`ring-2 ring-offset-2` を書くだけで accent + canvas オフセットが当たる。
+
+> グローバル outline は「予期しない focusable 要素にもリングが出る」セーフティネット。意図的なリングはコンポーネント側で明示する。
+
+---
+
+## 8. 共通コンポーネントの variant 一覧
+
+### 8.1 `Button`（`src/components/ui/Button.tsx`）
+
+- `variant`: `primary` / `secondary` / `ghost`
+- `size`: `sm` / `md` / `lg`（デフォルト `md`）
+- `type` 属性のデフォルトは `"button"`（フォーム内で誤って submit させない）
+- `forwardRef` 対応済
+
+| variant | クラス | 用途 |
+|---|---|---|
+| `primary` | `bg-accent text-canvas hover:opacity-90` | CTA |
+| `secondary` | `border border-line bg-canvas text-ink hover:bg-line/30` | 補助 |
+| `ghost` | `bg-transparent text-ink hover:bg-line/20` | カード内サブアクション |
+
+| size | クラス | 高さ |
+|---|---|---|
+| `sm` | `h-8 px-3 text-sm` | 32px |
+| `md` | `h-10 px-4 text-base` | 40px |
+| `lg` | `h-12 px-6 text-base` | 48px |
+
+`asChild`（Radix Slot 相当）は持たない。`<Link>` を Button スタイルで描画したい場合はラップして対応する。
+
+### 8.2 `Card`（`src/components/ui/Card.tsx`）
+
+- `variant` なし（最小設計）
+- デフォルトクラス: `rounded-xl border border-line/50 bg-canvas shadow-card p-6`
+- モバイル padding 切替は呼び出し側で `<Card className="p-4 sm:p-6">` のようにクラスを渡す
+- `forwardRef` 対応済
+
+> `Card.Header` / `Card.Body` / `Card.Footer` 等の composition API は本 Issue では実装しない（YAGNI）。
+
+### 8.3 本 Issue では含めない雛形
+
+- `Input` / `Select` / `Textarea` / `Label` 等のフォーム部品ラッパは Issue #2 で必要に応じて追加する。
+- `Skeleton` / `Spinner` / `Toast` / `Tooltip` / `Modal` 等は必要発生時に別 Issue で起票。
+
+---
+
+## 9. `cn` ヘルパの使い方
+
+`src/lib/cn.ts` は外部依存ゼロの 1 行実装:
+
+```ts
+export function cn(
+  ...classes: Array<string | false | null | undefined>
+): string {
+  return classes.filter(Boolean).join(" ");
+}
+```
+
+使い方:
+
+```tsx
+<button className={cn("px-4 py-2", isActive && "bg-accent", className)} />
+```
+
+注意点:
+
+- **`tailwind-merge` は使わない**。同一 Tailwind プロパティの上書きは保証されない（CSS 出力順依存）。
+- 雛形コンポーネント側のクラスを呼び出し側 `className` で上書きしたい場合は、衝突するプロパティ（例 `p-6` と `p-4`）を両方出力するのではなく、**雛形側のクラスを再構築できるよう設計する** か、呼び出し側で完全な指定を渡す（`<Card className="p-4 sm:p-6">`）。
+- 配列やオブジェクト記法（`cn({ active: true })`）はサポートしない。必要発生時に拡張する別 Issue を起票。
+- `tailwind-merge` の `twMerge` は同じ rest 引数 signature を持つため、将来差し替えが必要になった場合の API 互換性は保たれる。
+
+---
+
+## 10. 暫定 vs 確定の境界、および申し送り
+
+| 項目 | 状態 | 備考 |
+|---|---|---|
+| カラー 4 ロール（canvas / ink / line / accent） | 確定（Issue #7） | パレット名 4 トークンは中立キーとして併用可 |
+| spacing カスタムキー | 不採用（確定） | Tailwind デフォルトのみ運用、運用ルールは §3 |
+| borderRadius カスタムキー | 不採用（確定） | Tailwind デフォルトのみ運用、用途マッピングは §4 |
+| `boxShadow.card` / `card-hover` / `floating` の rgba 数値 | **暫定** | 実 UI が並んだ際の見え方で再調整余地あり。再調整は本 Issue 完了後の Issue #2 / #3 PR の中で「気付いたら微調整」運用 |
+| `letterSpacing.warning` = 0.06em | 暫定（中央値） | spec の 0.05em〜0.08em 範囲、実装で判断 |
+| ringColor / ringWidth / ringOffsetColor の DEFAULT | 確定 | accent #9CAEB8 / 2px / canvas #F8F6F2 |
+| Button primary のコントラスト比（accent on canvas text） | **要検討** | WCAG AA 不適合の可能性あり（約 1.8:1）。プレビューで実物確認後、(a) `text-ink` への変更 (b) `bg-ink` への切替 (c) Issue #22 のパレット再調整、のいずれかを後続 Issue で判断 |
+| spec ファイル（`docs/spec/result-dashboard.md` 等）の旧パレット参照 | 未対応 | Issue #22 で別途置換予定。後続実装は本 §2 のロールに読み替えて使う |
+| PDF 内 (`PdfDashboard`) で `shadow-card` を使うか | 未確定 | html2canvas のラスタライズで濁る可能性。Issue #5 実装時に `shadow-none` 運用の判断余地を残す |
+
+---
+
+## 11. 意思決定ログ
+
+各意思決定の根拠は `working/plans/issue-10_design-tokens-and-components.md` の該当節を参照する。
+
+| 決定 | プラン参照 |
+|---|---|
+| spacing カスタムキーを追加しない | §2.3 |
+| borderRadius カスタムキーを追加しない | §3.3 |
+| ink ベースの shadow を 3 種追加（黒シャドウ不採用） | §4.3 |
+| `letterSpacing.warning` のみ追加、`fontSize.hero` 等は追加しない | §5.3 |
+| ringColor / ringWidth / ringOffsetColor の DEFAULT を集約 | §6.2 |
+| `*:focus-visible` グローバル outline + 雛形側で ring 上書き | §7.3, §17.1 |
+| shadcn/ui を採用しない（自前最小実装） | §8.1 〜 §8.2 |
+| `cn` を極小自前実装にする（`clsx` / `tailwind-merge` 不採用） | §8.3 |
+| `Input` / フォーム部品ラッパは本 Issue では作らない | §8.2.3 |
+| `Card` の variant / composition API は持たない | §8.2.2, §21 R15 |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,7 +25,7 @@
     text-rendering: optimizeLegibility;
   }
   *:focus-visible {
-    outline: 2px solid #9caeb8;
+    outline: 2px solid #9CAEB8;
     outline-offset: 2px;
     border-radius: 2px;
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,10 +9,27 @@
  *   設定し、トークンレベルで切り替えること（<body> の Tailwind クラス上書きで
  *   ダーク対応を実装しないこと）。
  * - 背景色・文字色は layout.tsx の <body> クラス (bg-canvas text-ink) で当てる。
+ * - Issue #10 で @layer base に focus-visible リング統一 / palt /
+ *   optimizeLegibility / -webkit-tap-highlight-color の抑制を追加。
  */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    -webkit-tap-highlight-color: transparent;
+  }
+  body {
+    font-feature-settings: "palt" 1;
+    text-rendering: optimizeLegibility;
+  }
+  *:focus-visible {
+    outline: 2px solid #9caeb8;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+}
 
 @layer utilities {
   .text-balance {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,6 @@
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-10 p-8">
@@ -11,7 +14,7 @@ export default function Home() {
         </p>
       </section>
 
-      {/* TODO: UI 本実装時に削除 */}
+      {/* TODO: UI 本実装時に削除（Issue #2 / #3 / #4 / #5） */}
       <section aria-label="カラートークン プレビュー" className="w-full max-w-xl">
         <h2 className="mb-3 text-sm font-medium">Color tokens</h2>
         <ul className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -32,12 +35,68 @@ export default function Home() {
             <span className="text-xs">accent / #9CAEB8</span>
           </li>
         </ul>
-        <button
-          type="button"
-          className="mt-6 w-full rounded bg-accent px-4 py-2 font-medium text-canvas hover:opacity-90"
-        >
-          CTA サンプル（accent bg / canvas text）
-        </button>
+      </section>
+
+      {/* TODO: UI 本実装時に削除（Issue #2 / #3 / #4 / #5） */}
+      <section aria-label="角丸 / シャドウ プレビュー" className="w-full max-w-xl">
+        <h2 className="mb-3 text-sm font-medium">Radius &amp; Shadow tokens</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <div className="rounded-md border border-line/50 bg-canvas p-4 text-center text-xs">
+            rounded-md / 6px
+          </div>
+          <div className="rounded-xl border border-line/50 bg-canvas p-4 text-center text-xs">
+            rounded-xl / 12px
+          </div>
+          <div className="rounded-2xl border border-line/50 bg-canvas p-4 text-center text-xs">
+            rounded-2xl / 16px
+          </div>
+          <div className="rounded-xl bg-canvas p-4 text-center text-xs shadow-card">
+            shadow-card
+          </div>
+          <div className="rounded-xl bg-canvas p-4 text-center text-xs shadow-card-hover">
+            shadow-card-hover
+          </div>
+          <div className="rounded-xl bg-canvas p-4 text-center text-xs shadow-floating">
+            shadow-floating
+          </div>
+        </div>
+      </section>
+
+      {/* TODO: UI 本実装時に削除（Issue #2 / #3 / #4 / #5） */}
+      <section aria-label="Button プレビュー" className="w-full max-w-xl">
+        <h2 className="mb-3 text-sm font-medium">Button (variant × size)</h2>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button variant="primary" size="sm">
+            Primary sm
+          </Button>
+          <Button variant="primary" size="md">
+            Primary md
+          </Button>
+          <Button variant="primary" size="lg">
+            Primary lg
+          </Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button disabled>Disabled</Button>
+        </div>
+      </section>
+
+      {/* TODO: UI 本実装時に削除（Issue #2 / #3 / #4 / #5） */}
+      <section aria-label="Card プレビュー" className="w-full max-w-xl">
+        <h2 className="mb-3 text-sm font-medium">Card</h2>
+        <Card>
+          <h3 className="mb-2 text-base font-semibold">Card title</h3>
+          <p className="text-sm text-ink/80">
+            rounded-xl / border-line/50 / shadow-card / p-6 がデフォルト。
+            モバイルで padding を縮める場合は className=&quot;p-4 sm:p-6&quot; を渡す。
+          </p>
+          <div className="mt-4 flex gap-2">
+            <Button size="sm">アクション</Button>
+            <Button variant="ghost" size="sm">
+              サブ
+            </Button>
+          </div>
+        </Card>
       </section>
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -63,6 +63,19 @@ export default function Home() {
       </section>
 
       {/* TODO: UI 本実装時に削除（Issue #2 / #3 / #4 / #5） */}
+      <section aria-label="タイポグラフィ補強 プレビュー" className="w-full max-w-xl">
+        <h2 className="mb-3 text-sm font-medium">Typography tokens</h2>
+        <div className="rounded-xl border border-line/50 bg-canvas p-4 text-center">
+          <span className="text-xs font-bold uppercase tracking-warning text-ink">
+            CRITICAL OPPORTUNITY LOSS
+          </span>
+          <p className="mt-1 text-[10px] text-ink/60">
+            tracking-warning / 0.06em（Issue #4 で WarningBanner が消費予定）
+          </p>
+        </div>
+      </section>
+
+      {/* TODO: UI 本実装時に削除（Issue #2 / #3 / #4 / #5） */}
       <section aria-label="Button プレビュー" className="w-full max-w-xl">
         <h2 className="mb-3 text-sm font-medium">Button (variant × size)</h2>
         <div className="flex flex-wrap items-center gap-3">

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,41 @@
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost";
+export type ButtonSize = "sm" | "md" | "lg";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: "bg-accent text-canvas hover:opacity-90",
+  secondary: "border border-line bg-canvas text-ink hover:bg-line/30",
+  ghost: "bg-transparent text-ink hover:bg-line/20",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "h-8 px-3 text-sm",
+  md: "h-10 px-4 text-base",
+  lg: "h-12 px-6 text-base",
+};
+
+const baseClasses =
+  "inline-flex items-center justify-center gap-2 rounded-md font-medium transition-colors duration-150 " +
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 " +
+  "disabled:cursor-not-allowed disabled:opacity-50";
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = "primary", size = "md", className, type = "button", ...rest },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type={type}
+      className={cn(baseClasses, variantClasses[variant], sizeClasses[size], className)}
+      {...rest}
+    />
+  );
+});

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,14 @@
+import { forwardRef, type HTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+export type CardProps = HTMLAttributes<HTMLDivElement>;
+
+const baseClasses =
+  "rounded-xl border border-line/50 bg-canvas shadow-card p-6";
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
+  { className, ...rest },
+  ref,
+) {
+  return <div ref={ref} className={cn(baseClasses, className)} {...rest} />;
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,4 @@
+export { Button } from "./Button";
+export type { ButtonProps, ButtonVariant, ButtonSize } from "./Button";
+export { Card } from "./Card";
+export type { CardProps } from "./Card";

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -1,0 +1,13 @@
+/**
+ * 条件付き className 連結ヘルパ。
+ *
+ * - 用途: 雛形コンポーネントのデフォルトクラスと呼び出し側 className を結合する。
+ * - 設計: clsx / tailwind-merge を使わない極小実装。外部依存ゼロを維持する。
+ *   同一 Tailwind プロパティの上書きが必要な場合は呼び出し側で完全なクラスを
+ *   渡さず、雛形側のクラスを構成し直す方針とする (詳細: docs/design-tokens.md)。
+ */
+export function cn(
+  ...classes: Array<string | false | null | undefined>
+): string {
+  return classes.filter(Boolean).join(" ");
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,6 +27,26 @@ const config: Config = {
           "sans-serif",
         ],
       },
+      boxShadow: {
+        // ink (#72665B) ベースの rgba。canvas (#F8F6F2) 上で柔らかく見せる
+        card: "0 1px 2px 0 rgba(114, 102, 91, 0.05), 0 1px 3px 0 rgba(114, 102, 91, 0.04)",
+        "card-hover":
+          "0 4px 12px -2px rgba(114, 102, 91, 0.10), 0 2px 4px 0 rgba(114, 102, 91, 0.06)",
+        floating: "0 12px 24px -4px rgba(114, 102, 91, 0.12)",
+      },
+      letterSpacing: {
+        // 警告バナー見出し用 (docs/spec/warning-copy.md の 0.05em〜0.08em の中央値)
+        warning: "0.06em",
+      },
+      ringColor: {
+        DEFAULT: "#9CAEB8",
+      },
+      ringWidth: {
+        DEFAULT: "2px",
+      },
+      ringOffsetColor: {
+        DEFAULT: "#F8F6F2",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary

Issue #10 に基づき、後続実装 Issue（#2 / #3 / #4 / #5）が「クラス名で迷わずに書ける」状態を作るため、Tailwind トークンを拡張し共通コンポーネントの雛形を追加した。

- `tailwind.config.ts`: `boxShadow.card` / `card-hover` / `floating`（ink ベース rgba）、`letterSpacing.warning`、`ringColor` / `ringWidth` / `ringOffsetColor` の `DEFAULT` を追加
- `src/app/globals.css`: `@layer base` に `*:focus-visible` リング統一 / `body` の `palt` + `optimizeLegibility` / `html` の tap-highlight 抑制を追加
- `src/components/ui/Button.tsx`: variant `primary` / `secondary` / `ghost`、size `sm` / `md` / `lg` の最小実装（`forwardRef` + 自前 `cn`）
- `src/components/ui/Card.tsx`: `rounded-xl border border-line/50 bg-canvas shadow-card p-6` がデフォルト
- `src/components/ui/index.ts`: Button / Card の re-export
- `src/lib/cn.ts`: 外部依存ゼロの極小 `cn` ヘルパ
- `docs/design-tokens.md`: 運用ルール / 用途マッピング / 意思決定ログ
- `src/app/page.tsx`: Radius & Shadow / Button / Card プレビューを追加（後続 UI 実装で削除予定）

Closes #10

## 意思決定サマリー

- `spacing` / `borderRadius` / `fontSize` のカスタムキーは追加しない（Tailwind デフォルト + 運用ルールで揃える）
- ink ベースの shadow を 3 種追加（黒シャドウは canvas 上で濁るため）
- shadcn/ui は採用しない（Issue #8 の依存範囲を逸脱しないため）
- `cn` は外部依存ゼロの極小自前実装

## スコープ外

- `InputForm` / `ResultDashboard` / `WarningBanner` / `PdfDashboard` 本実装（Issue #2 / #3 / #4 / #5）
- `Input` / `Select` 等のフォーム部品ラッパ（Issue #2 で必要に応じて追加）
- ダークモード（マスター §3.3 でライト固定）
- spec 旧パレット参照の置換（Issue #22 別途起票）

## Test plan

- [x] \`npm run typecheck\` (0 errors)
- [x] \`npm run lint\` (0 errors)
- [x] \`npm run build\` (success / \`.next/static/css/\` に \`rgba(114,102,91,*)\` を含む CSS が出力)
- [ ] \`npm run dev\` で \`/\` を開き、Color / Radius & Shadow / Button / Card の 4 セクションが描画される
- [ ] DevTools で \`<button>\` の background-color が \`rgb(156, 174, 184)\`、border-radius 6px、transition-property が colors 系
- [ ] DevTools で \`<Card>\` の border-radius 12px、box-shadow が ink ベース rgba、padding 24px、border が \`rgba(190, 181, 170, 0.5)\`
- [ ] Tab キーで Button にフォーカスを移動した際、accent 色 2px のリングが描画される
- [ ] OS のダークモードに切り替えても画面配色が変わらない

## プラン参照

\`working/plans/issue-10_design-tokens-and-components.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)