### PR TITLE
feat(finish): PR 本文の Closes/Fixes/Resolves から Issue を自動クローズ

### DIFF
--- a/.claude/skills/finish/SKILL.md
+++ b/.claude/skills/finish/SKILL.md
@@ -1,49 +1,19 @@
 ---
 name: finish
-description: 現在のブランチのPRをマージし、分岐元ブランチに戻って最新化する
-argument-hint: "[追加の指示（任意）]"
+description: Merge the current branch's PR, delete feature branch, switch to base branch, pull latest, and close referenced issues. Usage /finish
 disable-model-invocation: true
-allowed-tools: Bash
 ---
 
-## 手順
+# Finish: PR Merge, Branch Cleanup & Update
 
-現在のブランチのPRをマージし、分岐元ブランチにチェックアウトして最新の状態に更新する。
+Merge the current branch's PR, delete the feature branch, switch back to the base branch, pull latest changes, and close any issues referenced by closure keywords (`Closes #N` / `Fixes #N` / `Resolves #N`) in the PR body.
 
-### 1. ベースブランチを特定
+`develop` ベースの PR では GitHub の自動クローズが発火しないため、PR 本文のクロージャ語を解析して該当 Issue を手動でクローズします（クロージャ語のない `Related: #N` 等の参照は対象外）。
 
-このプロジェクトではfeatureブランチは必ず `develop` から切るルールのため、ベースブランチは常に `develop` とする。なお、既存PRが存在する場合は `gh pr view --json baseRefName -q .baseRefName` で一致を確認しても良い。
-
-### 2. PRの状態を確認
+Run the finish script:
 
 ```bash
-gh pr view --json isDraft -q .isDraft
+bash .claude/skills/finish/finish.sh
 ```
 
-結果が `true`（ドラフト状態）の場合は「⚠️ このPRはドラフト状態です。Ready にしてから /finish を実行してください。」と警告を出し、**処理を中断する**。
-
-### 3. PRをマージ
-
-`gh pr merge` で現在のブランチのPRをマージする：
-
-```bash
-gh pr merge --merge --delete-branch
-```
-
-- `--merge` でマージコミットを作成
-- `--delete-branch` でリモート・ローカルのブランチを削除
-
-### 4. ベースブランチに切り替えて最新化
-
-```bash
-git checkout <base>
-git pull
-```
-
-### 5. 結果を表示
-
-現在のブランチと最新のログを表示して完了を確認する。
-
-### 補足ルール
-
-- ユーザーから追加の指示がある場合: $ARGUMENTS
+Display the script output to the user as-is. Do NOT follow up with additional actions (e.g., manual branch deletion) if the script reports errors or warnings.

--- a/.claude/skills/finish/finish.sh
+++ b/.claude/skills/finish/finish.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+set -euo pipefail
+
+# Protected branches that cannot run this script
+PROTECTED_BRANCHES=("develop" "main" "staging")
+
+# === 0. Check dependencies ===
+if ! command -v jq &>/dev/null; then
+  echo "⚠️ エラー: jq がインストールされていません。インストールしてから再実行してください。"
+  exit 1
+fi
+
+# === 1. Check current branch ===
+branch=$(git branch --show-current)
+for protected in "${PROTECTED_BRANCHES[@]}"; do
+  if [[ "$branch" == "$protected" ]]; then
+    echo "⚠️ エラー: 現在のブランチは '${branch}' です。フィーチャーブランチから実行してください。"
+    exit 1
+  fi
+done
+feature_branch="$branch"
+
+# === 2. Check for associated PR ===
+pr_output=$(gh pr view --json number,baseRefName,state,isDraft,body 2>&1) || {
+  echo "⚠️ エラー: 現在のブランチに紐づくPRが見つかりません"
+  echo "  詳細: $pr_output"
+  exit 1
+}
+pr_json="$pr_output"
+
+number=$(echo "$pr_json" | jq -r '.number')
+base_ref=$(echo "$pr_json" | jq -r '.baseRefName')
+state=$(echo "$pr_json" | jq -r '.state')
+is_draft=$(echo "$pr_json" | jq -r '.isDraft')
+pr_body=$(echo "$pr_json" | jq -r '.body')
+
+# === 3. Handle PR state ===
+skip_merge=false
+messages=()
+
+case "$state" in
+  MERGED)
+    skip_merge=true
+    messages+=("ℹ️ PR #${number} は既にマージ済みです")
+    ;;
+  CLOSED)
+    skip_merge=true
+    messages+=("⚠️ 警告: PR #${number} はマージされずにクローズされています")
+    ;;
+  OPEN)
+    if [[ "$is_draft" == "true" ]]; then
+      echo "⚠️ エラー: PR #${number} はまだDraft状態です。Ready for reviewにしてから実行してください。"
+      exit 1
+    fi
+    ;;
+esac
+
+# === 4. Merge the PR (if needed) ===
+if [[ "$skip_merge" == "false" ]]; then
+  if ! gh pr merge --merge --delete-branch; then
+    echo "⚠️ エラー: PR #${number} のマージに失敗しました"
+    exit 1
+  fi
+  messages+=("✅ PR #${number} をマージしました")
+fi
+
+# === 5. Switch to base branch and pull latest ===
+if ! git switch "$base_ref"; then
+  echo "⚠️ エラー: ブランチ '${base_ref}' への切り替えに失敗しました"
+  exit 1
+fi
+if ! git pull origin "$base_ref"; then
+  echo "⚠️ エラー: ブランチ '${base_ref}' のpullに失敗しました"
+  exit 1
+fi
+
+# === 6. Delete feature branch (if not already deleted by gh pr merge) ===
+git fetch --prune
+if git branch --list "$feature_branch" | grep -q .; then
+  if git branch -d "$feature_branch" 2>/dev/null; then
+    messages+=("✅ ブランチ '${feature_branch}' を削除しました")
+  else
+    messages+=("⚠️ 警告: ブランチ '${feature_branch}' の削除に失敗しました。手動で削除してください。")
+  fi
+else
+  messages+=("✅ ブランチ '${feature_branch}' を削除しました")
+fi
+
+messages+=("✅ ブランチ '${base_ref}' に切り替え、最新に更新しました")
+
+# === 7. Close referenced issues (develop マージでは GitHub 自動クローズが発火しないため手動補完) ===
+# PR 本文から "Closes #N" / "Close #N" / "Closed #N" / "Fix(es/ed) #N" / "Resolve(s/d) #N" を抽出
+# (大文字小文字は問わない、コロン任意、複数番号「Closes #1, #2」も対応)
+referenced_issues=$(echo "$pr_body" \
+  | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?):?[[:space:]]+#[0-9]+([[:space:]]*,[[:space:]]*#[0-9]+)*' \
+  | grep -oE '#[0-9]+' \
+  | tr -d '#' \
+  | sort -u)
+
+if [[ -n "$referenced_issues" ]]; then
+  for issue_num in $referenced_issues; do
+    issue_state=$(gh issue view "$issue_num" --json state -q .state 2>/dev/null) || {
+      messages+=("ℹ️ Issue #${issue_num}: 取得失敗（スキップ）")
+      continue
+    }
+    if [[ "$issue_state" == "OPEN" ]]; then
+      if gh issue close "$issue_num" --comment "PR #${number} で \`${base_ref}\` にマージ済み。" >/dev/null 2>&1; then
+        messages+=("✅ Issue #${issue_num} をクローズしました")
+      else
+        messages+=("⚠️ Issue #${issue_num} のクローズに失敗しました")
+      fi
+    else
+      messages+=("ℹ️ Issue #${issue_num} は既に ${issue_state} 状態（スキップ）")
+    fi
+  done
+fi
+
+# === Output results ===
+printf '%s\n' "${messages[@]}"


### PR DESCRIPTION
## Summary

- `develop` ベースの PR は GitHub の自動クローズ機能が発火しないため、`/finish` 実行時に **PR 本文のクロージャ語（`Closes`/`Close`/`Closed`/`Fix`/`Fixes`/`Fixed`/`Resolves`/`Resolved` + `#N`）を解析し、該当 OPEN Issue を手動でクローズ** するステップを追加
- `Related: #N` 等の単純参照は対象外（誤クローズ防止）
- マージ参照コメント付き（「PR #N で \`develop\` にマージ済み。」）

## 背景

`gh pr view --json closingIssuesReferences` も `develop` ベース PR では空配列を返すため、PR 本文のテキスト解析で補完する設計を採用。実際にこの不在が原因で過去 4 件（#8 / #9 / #10 / #22）の Issue が完了済みのまま OPEN 状態で滞留していた。

## 変更ファイル

- `.claude/skills/finish/finish.sh` — マージ後ステップ 7 を追加、本文パース→`gh issue close` ループ
- `.claude/skills/finish/SKILL.md` — 新挙動と運用目的を説明文に追記

## Test plan

- [x] `bash -n finish.sh` シンタックスチェック通過
- [x] 過去 PR #23 本文に対する正規表現テスト → `#8` のみ抽出（`Related: #24` は除外）
- [x] 過去 PR #27 本文に対する正規表現テスト → `#22` のみ抽出
- [ ] 次回の `/finish` 実行時に新ステップが期待通り動作することを実機確認（本 PR マージ時に自動的に発火する）

🤖 Generated with [Claude Code](https://claude.com/claude-code)