### PR TITLE
feat(domain): 独自ドメイン roi.nekonimatatabi.com を本番 URL として確定 (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm run lint
 
 ## デプロイ
 
-本リポジトリは Cloudflare Pages のダッシュボードで GitHub 連携を構成済みで、push をトリガーに自動デプロイされます。
+本リポジトリは Cloudflare Pages のダッシュボードで GitHub 連携を構成済みで、push をトリガーに自動デプロイされます。本番 URL は `https://roi.nekonimatatabi.com`（Apex を正規ホストとして運用）。
 
 ### ブランチ運用
 
@@ -72,8 +72,15 @@ npm run lint
 
 `NEXT_PUBLIC_SITE_URL` を Production / Preview それぞれに設定してください。`src/app/layout.tsx` の `metadataBase` がこの値を参照し、OG / Twitter Card の絶対 URL を生成します。
 
-- Production: 本番ドメイン確定までは Cloudflare Pages が発行する `*.pages.dev` URL を暫定値として設定
+- Production: `https://roi.nekonimatatabi.com`
 - Preview: プレビュー用 `*.pages.dev` URL（プロジェクト固定 URL）
+
+### 独自ドメイン運用方針
+
+- 正規ホスト: Apex (`roi.nekonimatatabi.com`)。`www.roi.nekonimatatabi.com` を使う場合は Cloudflare の Redirect Rule で 301 を返す
+- SSL/TLS モード: **Full (strict)**、Always Use HTTPS = On、Automatic HTTPS Rewrites = On、Minimum TLS Version = 1.2
+- HSTS: 段階導入。初期 `max-age=300`（5 分）で開始し、1〜2 週間の安定運用後に `max-age=31536000` + `includeSubDomains` へ引き上げる（Preload 申請は別 Issue で扱う）
+- 詳細な Cloudflare ダッシュボード設定値は Issue #12 のコメントおよび関連プランを参照
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ npm run lint
 
 ### 独自ドメイン運用方針
 
-- 正規ホスト: Apex (`roi.nekonimatatabi.com`)。`www.roi.nekonimatatabi.com` を使う場合は Cloudflare の Redirect Rule で 301 を返す
+- 正規ホスト: Apex (`roi.nekonimatatabi.com`)。将来 `www.roi.nekonimatatabi.com` を併設する場合は Cloudflare の Redirect Rule で 301 を返す方針（現時点では併設なし）
 - SSL/TLS モード: **Full (strict)**、Always Use HTTPS = On、Automatic HTTPS Rewrites = On、Minimum TLS Version = 1.2
 - HSTS: 段階導入。初期 `max-age=300`（5 分）で開始し、1〜2 週間の安定運用後に `max-age=31536000` + `includeSubDomains` へ引き上げる（Preload 申請は別 Issue で扱う）
-- 詳細な Cloudflare ダッシュボード設定値は Issue #12 のコメントおよび関連プランを参照
+- 詳細な Cloudflare ダッシュボード設定値は Issue #12 のコメントを参照
 
 ## ドキュメント
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ const notoSansJp = Noto_Sans_JP({
 });
 
 const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL ?? "https://matatabi-calculator.example";
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://roi.nekonimatatabi.com";
 const SITE_NAME = "またたび計算機";
 const SITE_DESCRIPTION = "中小企業向け ROI 診断アプリ「またたび計算機」";
 


### PR DESCRIPTION
## 概要

Issue #12 のリポジトリ側設定を実施。独自ドメイン `roi.nekonimatatabi.com` を本番 URL として確定し、`metadataBase` フォールバック値と README を実ドメインで埋める。Cloudflare ダッシュボード側の DNS / カスタムドメイン / SSL/TLS / 環境変数更新作業はマージ後にユーザーが手動で実施。

## 詳細

### M0 確定事項（ステークホルダー判断）

| 項目 | 確定値 |
| --- | --- |
| 採用ドメイン | `roi.nekonimatatabi.com` |
| 正規ホスト | Apex |
| SSL/TLS モード | Full (strict) |
| HSTS 初期 max-age | `300`（5 分。段階導入） |

### リポジトリ側変更

- **`src/app/layout.tsx`**: `metadataBase` フォールバック値を `https://matatabi-calculator.example` から `https://roi.nekonimatatabi.com` に置換。`NEXT_PUBLIC_SITE_URL` 未設定時の保険を実ドメインに更新
- **`README.md`**:
  - 「デプロイ」節冒頭に本番 URL（Apex 正規）を明記
  - 「必須環境変数」節の Production 行を `https://roi.nekonimatatabi.com` で確定
  - 「独自ドメイン運用方針」節を新設（正規ホスト / SSL/TLS / HSTS 段階導入の方針を記載）

### マージ後にユーザーが Cloudflare ダッシュボードで実施する作業

> ⚠️ 以下は Cloudflare アカウント保有者の手動作業です。本 PR には含まれません。

#### M1. Cloudflare DNS にレコードを追加（ゾーン: `nekonimatatabi.com`）

- Type: `CNAME` / Name: `roi` / Target: `<project>.pages.dev` / **Proxied（オレンジ雲）**
- 必要に応じて Type: `CNAME` / Name: `www.roi` / Target: `<project>.pages.dev` / Proxied も追加（リダイレクト元として）

#### M2. Cloudflare Pages にカスタムドメインを接続

- Workers & Pages → `matatabi-calculator` → Custom domains → Set up a custom domain
- `roi.nekonimatatabi.com` を入力 → 接続。証明書ステータスが Active になるまで待つ

#### M3. SSL/TLS モードと HTTPS 強制 / リダイレクトルールを適用

- SSL/TLS → Overview: **Full (strict)**
- SSL/TLS → Edge Certificates: **Always Use HTTPS = On** / **Automatic HTTPS Rewrites = On** / **Minimum TLS Version = 1.2** / **HSTS Enable（max-age=300、includeSubDomains/Preload は Off）**
- Rules → Redirect Rules（www.roi も併設した場合）: `Hostname equals www.roi.nekonimatatabi.com` → `Dynamic redirect` `concat("https://roi.nekonimatatabi.com", http.request.uri.path)` / 301 / Preserve query string On

#### M4. Pages の `NEXT_PUBLIC_SITE_URL` 環境変数を実ドメインに更新

- Pages プロジェクト → Settings → Environment variables → Production の `NEXT_PUBLIC_SITE_URL` を `https://roi.nekonimatatabi.com` に更新
- Deployments → 最新 Production デプロイ → **Retry deployment** で再ビルドし、`metadataBase` の値を反映

#### M5. HTTPS アクセスの最終確認

- `curl -I https://roi.nekonimatatabi.com/` → HTTP/2 200、`server: cloudflare`
- `curl -I http://roi.nekonimatatabi.com/` → 301 → `https://...`
- `dig roi.nekonimatatabi.com +short` で Cloudflare のエッジ IP が返る
- ブラウザで `https://roi.nekonimatatabi.com/` を開き、`<title>またたび計算機</title>` が表示される
- ページソースの `og:url` などの絶対 URL が `https://roi.nekonimatatabi.com/...` に解決される

## 参考

- Closes #12
- 依存していた Issue #11（Cloudflare Pages プロジェクト作成）はマージ済み
- 関連: Issue #14（アクセス解析 GA4）、別途起票予定の SEO 整備 Issue（`robots.txt` / `sitemap.xml` / Search Console / HSTS Preload 申請）

## 注意事項

- **ローカル検証実績**（PR 作成前に実施済み）
  - `npm run lint` ✅ 0 件
  - `npm run typecheck` ✅ 0 件
  - `npm run build` ✅ 成功、`out/index.html` に `roi.nekonimatatabi.com` が反映されたことを確認
- **HSTS 段階導入**: 初期 `max-age=300`。1〜2 週間の安定運用を経てから `max-age=31536000; includeSubDomains` への引き上げを別 Issue で扱う。Preload 申請も別 Issue
- **本 Issue のスコープ外**:
  - `public/robots.txt` / `public/sitemap.xml` の追加（SEO 整備 Issue）
  - Google Search Console 登録（同上）
  - HSTS Preload リスト申請
  - メールホスティング MX レコード（本サービスはメール不要）
  - Cloudflare Access による preview URL 認証保護
- **マージ前のレジストラ確認**: ゾーン `nekonimatatabi.com` が既に Cloudflare DNS 管理下にあることを M1 着手前に確認してください。外部レジストラ管理下の場合は NS 切替が前提タスクとして必要
