### PR TITLE
feat(layout): Header / 404 / error / loading の整備（公開準備の残ピース） (#36)

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowLeft, RefreshCw } from "lucide-react";
+import { SectionEyebrow } from "@/components/landing/SectionEyebrow";
+
+type ErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const isDev = process.env.NODE_ENV === "development";
+
+  return (
+    <main
+      aria-labelledby="error-heading"
+      className="relative flex min-h-[60vh] flex-col items-center justify-center overflow-hidden px-4 py-20 sm:px-8 sm:py-28"
+    >
+      <div
+        aria-hidden="true"
+        className="bg-grain pointer-events-none absolute inset-0 -z-10"
+      />
+      <Image
+        src="/brand/cat-deco-1.svg"
+        alt=""
+        aria-hidden="true"
+        width={160}
+        height={160}
+        className="pointer-events-none mb-6 h-24 w-24 rotate-6 opacity-50 animate-fade-up sm:h-28 sm:w-28"
+      />
+      <div className="animate-fade-up [animation-delay:80ms]">
+        <SectionEyebrow number="500" label="Error" align="center" />
+      </div>
+      <h1
+        id="error-heading"
+        className="mt-5 text-balance text-center text-3xl font-bold leading-tight text-ink animate-fade-up [animation-delay:160ms] sm:text-4xl"
+      >
+        申し訳ありません、予期せぬエラーが発生しました
+      </h1>
+      <p className="mt-5 max-w-md text-center text-base leading-relaxed text-ink/80 animate-fade-up [animation-delay:240ms]">
+        一時的な問題の可能性があります。お手数ですが、再読み込みをお試しください。問題が解消しない場合はトップページへお戻りください。
+      </p>
+      <div className="mt-8 flex flex-col items-center gap-3 animate-fade-up [animation-delay:320ms] sm:flex-row sm:gap-4">
+        <button
+          type="button"
+          onClick={() => reset()}
+          className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-ink px-6 text-base font-medium text-canvas shadow-card transition-[transform,box-shadow,opacity] duration-200 hover:-translate-y-0.5 hover:opacity-95 hover:shadow-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+        >
+          <RefreshCw aria-hidden="true" className="h-5 w-5" />
+          再読み込み
+        </button>
+        <Link
+          href="/"
+          className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-line bg-canvas px-6 text-base font-medium text-ink transition-colors duration-150 hover:bg-line/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+        >
+          <ArrowLeft aria-hidden="true" className="h-5 w-5" />
+          トップページへ戻る
+        </Link>
+      </div>
+      {isDev ? (
+        <details className="mt-10 max-w-2xl rounded-xl border border-line/50 bg-canvas p-4 text-left text-xs text-ink/70 shadow-card">
+          <summary className="cursor-pointer font-medium text-ink">
+            エラー詳細（開発環境のみ表示）
+          </summary>
+          <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed">
+            {error.message}
+            {error.digest ? `\n\ndigest: ${error.digest}` : null}
+          </pre>
+        </details>
+      ) : null}
+    </main>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -69,7 +69,7 @@ export default function ErrorPage({ error, reset }: ErrorPageProps) {
           <summary className="cursor-pointer font-medium text-ink">
             エラー詳細（開発環境のみ表示）
           </summary>
-          <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed">
+          <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">
             {error.message}
             {error.digest ? `\n\ndigest: ${error.digest}` : null}
           </pre>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Inter, Noto_Sans_JP } from "next/font/google";
 import Script from "next/script";
 import { Footer } from "@/components/ui/Footer";
+import { Header } from "@/components/ui/Header";
 import "./globals.css";
 
 const CF_BEACON_TOKEN = process.env.NEXT_PUBLIC_CF_BEACON_TOKEN;
@@ -79,6 +80,7 @@ export default function RootLayout({
         className={`${inter.variable} ${notoSansJp.variable} bg-canvas text-ink antialiased`}
       >
         <div className="flex min-h-screen flex-col">
+          <Header />
           <div className="flex-1">{children}</div>
           <Footer />
         </div>

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,31 @@
+import Image from "next/image";
+
+export default function Loading() {
+  return (
+    <main
+      role="status"
+      aria-live="polite"
+      aria-label="読み込み中"
+      className="flex min-h-[60vh] flex-col items-center justify-center gap-5 px-4 py-20 sm:px-8 sm:py-28"
+    >
+      <Image
+        src="/brand/cat-deco-1.svg"
+        alt=""
+        aria-hidden="true"
+        width={96}
+        height={96}
+        className="h-16 w-16 animate-pulse opacity-70 motion-safe:animate-spin sm:h-20 sm:w-20"
+      />
+      <p className="text-sm font-medium text-ink/70 sm:text-base">
+        読み込み中...
+      </p>
+      <div
+        aria-hidden="true"
+        className="flex w-full max-w-sm flex-col gap-2"
+      >
+        <span className="h-3 w-full animate-pulse rounded-md bg-line/30" />
+        <span className="h-3 w-3/4 animate-pulse rounded-md bg-line/30" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { SectionEyebrow } from "@/components/landing/SectionEyebrow";
+
+export const metadata: Metadata = {
+  title: "ページが見つかりません",
+  robots: { index: false, follow: false },
+};
+
+export default function NotFound() {
+  return (
+    <main
+      aria-labelledby="not-found-heading"
+      className="relative flex min-h-[60vh] flex-col items-center justify-center overflow-hidden px-4 py-20 sm:px-8 sm:py-28"
+    >
+      <div
+        aria-hidden="true"
+        className="bg-grain pointer-events-none absolute inset-0 -z-10"
+      />
+      <Image
+        src="/brand/cat-deco-1.svg"
+        alt=""
+        aria-hidden="true"
+        width={160}
+        height={160}
+        className="pointer-events-none mb-6 h-24 w-24 -rotate-12 opacity-60 animate-fade-up sm:h-28 sm:w-28"
+      />
+      <div className="animate-fade-up [animation-delay:80ms]">
+        <SectionEyebrow number="404" label="Not Found" align="center" />
+      </div>
+      <h1
+        id="not-found-heading"
+        className="mt-5 text-balance text-center text-3xl font-bold leading-tight text-ink animate-fade-up [animation-delay:160ms] sm:text-4xl"
+      >
+        お探しのページは
+        <span className="underline-brush">見つかりません</span>
+        でした
+      </h1>
+      <p className="mt-5 max-w-md text-center text-base leading-relaxed text-ink/80 animate-fade-up [animation-delay:240ms]">
+        URL のご入力に誤りがあるか、ページが移動・削除された可能性があります。お手数ですが、トップページからお探しください。
+      </p>
+      <Link
+        href="/"
+        className="mt-8 inline-flex h-12 items-center justify-center gap-2 rounded-md bg-ink px-6 text-base font-medium text-canvas shadow-card transition-[transform,box-shadow,opacity] duration-200 hover:-translate-y-0.5 hover:opacity-95 hover:shadow-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 animate-fade-up [animation-delay:320ms]"
+      >
+        <ArrowLeft aria-hidden="true" className="h-5 w-5" />
+        トップページへ戻る
+      </Link>
+    </main>
+  );
+}

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -21,11 +21,7 @@ const DEFAULT_CTA: Required<HeaderNavCtaConfig> = {
 };
 
 export function Header({ className, cta }: HeaderProps = {}) {
-  const ctaConfig = {
-    label: cta?.label ?? DEFAULT_CTA.label,
-    shortLabel: cta?.shortLabel ?? DEFAULT_CTA.shortLabel,
-    href: cta?.href ?? DEFAULT_CTA.href,
-  };
+  const ctaConfig = { ...DEFAULT_CTA, ...(cta ?? {}) };
 
   return (
     <header
@@ -39,7 +35,7 @@ export function Header({ className, cta }: HeaderProps = {}) {
         <Link
           href="/"
           aria-label="またたび計算機 トップページ"
-          className="inline-flex items-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+          className="inline-flex items-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
         >
           <Image
             src="/brand/logo-header.svg"

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -1,0 +1,74 @@
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+export type HeaderNavCtaConfig = {
+  label: string;
+  shortLabel?: string;
+  href: string;
+};
+
+export type HeaderProps = {
+  className?: string;
+  cta?: HeaderNavCtaConfig;
+};
+
+const DEFAULT_CTA: Required<HeaderNavCtaConfig> = {
+  label: "診断を始める",
+  shortLabel: "診断 →",
+  href: "/calculate",
+};
+
+export function Header({ className, cta }: HeaderProps = {}) {
+  const ctaConfig = {
+    label: cta?.label ?? DEFAULT_CTA.label,
+    shortLabel: cta?.shortLabel ?? DEFAULT_CTA.shortLabel,
+    href: cta?.href ?? DEFAULT_CTA.href,
+  };
+
+  return (
+    <header
+      role="banner"
+      className={cn(
+        "sticky top-0 z-40 border-b border-line/30 bg-canvas/80 backdrop-blur-sm",
+        className,
+      )}
+    >
+      <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-between px-4 sm:h-16 sm:px-8">
+        <Link
+          href="/"
+          aria-label="またたび計算機 トップページ"
+          className="inline-flex items-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+        >
+          <Image
+            src="/brand/logo-header.svg"
+            alt=""
+            aria-hidden="true"
+            width={200}
+            height={40}
+            priority
+            className="h-7 w-auto sm:h-8"
+          />
+        </Link>
+        <Link
+          href={ctaConfig.href}
+          className={cn(
+            "inline-flex items-center justify-center gap-2 rounded-md font-medium",
+            "border border-line bg-canvas text-ink hover:bg-line/30",
+            "transition-colors duration-150",
+            "h-9 px-3 text-sm sm:h-10 sm:px-4 sm:text-base",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+          )}
+        >
+          <span className="sm:hidden">{ctaConfig.shortLabel}</span>
+          <span className="hidden sm:inline">{ctaConfig.label}</span>
+          <ArrowRight
+            aria-hidden="true"
+            className="hidden h-4 w-4 sm:inline-block"
+          />
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -6,3 +6,5 @@ export { Footer } from "./Footer";
 export type { FooterProps } from "./Footer";
 export { Accordion } from "./Accordion";
 export type { AccordionItem, AccordionProps } from "./Accordion";
+export { Header } from "./Header";
+export type { HeaderProps, HeaderNavCtaConfig } from "./Header";


### PR DESCRIPTION
## 概要

Issue #36 の対応として、本番公開・営業利用前に欠落していた App Router 規約ファイル群（Header / not-found / error / loading）を整備。Issue #34 の LP で確立した「編集記号 / グレイン / ブラシ下線 / 猫モチーフ」のアートディレクションを継承し、サイト全体の体験を統一。

## 詳細

- **`src/components/ui/Header.tsx` 新規**: `sticky top-0 z-40 border-b border-line/30 bg-canvas/80 backdrop-blur-sm` で薄いライン + 軽い背景透過。左にロゴ `<Link href="/" aria-label="またたび計算機 トップページ">`、右に Button-secondary 風の `<Link href="/calculate">`「診断を始める」（モバイル時 "診断 →"）。`HeaderProps` の `cta` で文言・遷移先を上書き可能、未指定時は既定値で動作。
- **`src/app/layout.tsx` 変更**: `<Header />` を `<Footer />` と同列に `<RootLayout>` 内で全ページ共通描画。ページ側 (`/`, `/calculate`, `/privacy`, `/terms`, 404, error) では Header を呼ばない（二重描画防止）。
- **`src/app/not-found.tsx` 新規**: `SectionEyebrow number="404" label="Not Found" align="center"`、見出し「お探しのページは見つかりませんでした」（"見つかりません" を `underline-brush` で強調）、トップへ戻る CTA、`cat-deco-1.svg` を -12° 回転で装飾。`bg-grain` + `animate-fade-up` stagger 反映。`metadata.robots = { index: false, follow: false }`。
- **`src/app/error.tsx` 新規** (`"use client"`): `useEffect` で `console.error(error)` を残し、`SectionEyebrow number="500"` で 404 と統一感。主 CTA「再読み込み」(`reset()`) と副 CTA「トップページへ戻る」を併設。`process.env.NODE_ENV === "development"` のときのみ `error.message` / `digest` を `<details>` で開示。
- **`src/app/loading.tsx` 新規**: 中央に `cat-deco-1.svg` の `motion-safe:animate-spin` + `animate-pulse` 重ねがけ、「読み込み中...」テキスト、スケルトンブロック 2 本。`role="status" aria-live="polite"`。
- **`src/components/ui/index.ts` 変更**: Header / HeaderProps / HeaderNavCtaConfig の re-export を追加。

### 検証結果

- `npm run lint` ✅ / `npm run typecheck` ✅ / `npm run build` ✅
- `out/index.html` / `out/calculate.html` / `out/privacy.html` / `out/terms.html` / `out/404.html` のすべてに `<header role="banner">` が含まれることを確認
- `out/404.html` の `<head>` に `<meta name="robots" content="noindex, nofollow">` が含まれること、`<title>ページが見つかりません | またたび計算機</title>` が `title.template` 経由で適用されていることを確認
- `out/_next/static/chunks/app/error-*.js` が生成されていることを確認

### マージ後 / 後続 Issue への申し送り

- [ ] Lighthouse モバイル計測（Performance ≥ 90 / Accessibility ≥ 95 / SEO ≥ 95）はプレビュー URL 発行後に実施
- [ ] Safari / iOS 実機で sticky + `backdrop-blur-sm` の動作を確認（Tailwind 3.4 は `-webkit-backdrop-filter` を自動出力）
- [ ] `error.tsx` の動作確認は `next dev` 環境で一時的に `throw new Error(...)` を埋め込む方式で実施（本 PR には含めない）

## 参考

- Plan: `working/plans/issue-36-header-not-found-error-loading_260501214109.md`
- Closes #36

## 注意事項

- Header / 404 / error の CTA は `<Link>` + Button 風クラス再構築（Issue #34 / `docs/design-tokens.md §8.1` 方針継承）。`error.tsx` の「再読み込み」のみ `reset()` を呼ぶため `<button>` を使用（クライアント関数のため `<Link>` 化不可）。
- `loading.tsx` は `output: "export"` 環境では実運用時の発火頻度は極めて低いが、将来 Suspense 境界を入れた際の白画面回避保険として最小実装を配置。
- Header の `priority` 属性は `next/image` のロゴに付与（LCP 候補のためそのまま）。
- ロゴは `public/brand/logo-header.svg` の暫定アセットを参照。本制作差し替えは別 Issue で対応予定。
