### PR TITLE
docs(security): §6.4.2 の TODO を解消し Next.js 14→16 更新 Issue #53 を埋める

### DIFF
--- a/docs/security/jspdf-vulnerabilities.md
+++ b/docs/security/jspdf-vulnerabilities.md
@@ -158,10 +158,8 @@
 
 #### 6.4.2 別 Issue 化方針
 
-- 「Next.js 14 → 16 メジャー更新」を独立した調査・移行 Issue として切り出す（本 Issue 完了後に起票予定）。`postcss` / `glob` は `next` の依存解決に追従する形で同時更新する想定。
+- 「Next.js 14 → 16 メジャー更新」は **Issue #53** として切り出し済み（2026-05-01 起票）。`postcss` / `glob` は `next` の依存解決に追従する形で同時更新する想定。
 - 本 Issue（#50）完了時点では、`.github/workflows/security-audit.yml` の `audit-level=critical` を維持し、high レベルの CI 赤化は当面起こさない運用とする（critical 1 件の赤化のみ §6.2 に従って許容）。
-
-> **TODO（追跡用）**: 「Next.js 14 → 16 メジャー更新」Issue が起票され次第、本節（§6.4.2）の 1 つ目の箇条書きに当該 Issue 番号（例: `#XX`）を追記すること。Issue #50 のマージ後の作業として実施し、起票が漏れた場合は本書の `git blame` 経由で本 TODO を発見できるよう、行を残しておく。
 
 ## 7. レビュー観点（Issue #5 担当者向け申し送り）
 


### PR DESCRIPTION
## 概要

Issue #50 のマージ時点で `docs/security/jspdf-vulnerabilities.md §6.4.2` に残した TODO（「Next.js 14 → 16 更新 Issue が起票され次第、Issue 番号を追記する」）を解消する。Issue #53 が起票されたため、§6.4.2 の 1 つ目の箇条書きに Issue 番号を明示し、不要になった TODO ブロックを削除する。

## 詳細

- §6.4.2 1 つ目の箇条書きを更新: 「（本 Issue 完了後に起票予定）」を「**Issue #53** として切り出し済み（2026-05-01 起票）」に置換
- §6.4.2 末尾の TODO ブロッククォート（4 行）を削除。追跡可能性は §6.4.2 本文の Issue 番号で担保される

## 参考

Refs #50 #53

- 起票済み追従 Issue: #53（chore(deps): Next.js 14 → 16 メジャー更新と関連 high 脆弱性の解消）
- 関連文書: `docs/security/jspdf-vulnerabilities.md §6.4`

## 注意事項

- 本 PR は文書の 1 行の差し替えのみ。コード／依存変更なし
- Issue #53 自体の作業（実際のメジャー更新）はスコープ外
