### PR TITLE
feat(lib): 計算ロジック・フォーマッタ・定数の共通ユーティリティ実装 (#38)

### DIFF
--- a/src/lib/calculation.ts
+++ b/src/lib/calculation.ts
@@ -1,0 +1,187 @@
+/**
+ * ROI 診断アプリ「またたび計算機」の計算ロジック本体。
+ *
+ * - 仕様: docs/spec/calculation-logic.md §5（最終計算式）/ §6（丸めルール）/ §7（スピード警告）
+ *         docs/spec/input-form.md §9（単位変換）
+ * - 原則: 純粋関数。UI に依存しない。内部計算は円単位・浮動小数のまま保持し、
+ *         丸め・単位文字列付与は format.ts に閉じ込める。
+ * - ガード: NaN / Infinity / 負値は受け入れ不能とし、フォールバック 0 を返す
+ *           （仕様書 §6「負値発生時は 0 として表示」）。
+ */
+
+import {
+  DEFAULT_DAYS_PER_MONTH,
+  DEFAULT_HOURLY_WAGE,
+  DEFAULT_HOURS_PER_DAY,
+  INSOURCING_LEVELS,
+  MONTHS_IN_PERIOD,
+  MONTHS_PER_YEAR,
+  REPAIRS_PER_YEAR,
+  SPEED_WARNING_THRESHOLD_MONTHS,
+  YEARS_IN_PERIOD,
+  YEN_PER_MAN_YEN,
+} from "./constants";
+import type { InsourcingLevel } from "./constants";
+
+/**
+ * 計算入力。仕様書 §5 の `Inputs` 型に対応。
+ *
+ * - 単位はすべて円（`monthlyVendorCost` / `repairCost` / `hourlyWage`）または
+ *   人 / 月 / 時間 / 日。UI 側の万円入力は `manYenToYen` で変換してから渡すこと。
+ * - `hourlyWage` / `hoursPerDay` / `daysPerMonth` は詳細設定（オプション）。
+ *   未指定時は constants.ts の `DEFAULT_*` を使用する。
+ */
+export interface CalculationInput {
+  monthlyVendorCost: number;
+  repairCost: number;
+  manualWorkerCount: number;
+  updateWaitMonths: number;
+  insourcingLevel: InsourcingLevel;
+  hourlyWage?: number;
+  hoursPerDay?: number;
+  daysPerMonth?: number;
+}
+
+/**
+ * 計算結果。仕様書 §5 の `CalculationResult` 型に対応。
+ *
+ * - 金額系プロパティはすべて円単位の浮動小数。表示時に format.ts で万円丸めする。
+ * - `speedWarning`: `updateWaitMonths >= 3` で `true`（仕様書 §7）。
+ * - `insourcingGap`: `1 - insourcingLevel`（0..1）。止血額への乗算係数。
+ */
+export interface CalculationOutput {
+  threeYearSavings: number;
+  annualProfitCreation: number;
+  threeYearProfitCreation: number;
+  totalThreeYearImpact: number;
+  speedWarning: boolean;
+  insourcingGap: number;
+}
+
+/**
+ * 数値を安全な範囲に正規化する。NaN / Infinity / `min` 未満の値は `fallback` に置換する。
+ * 仕様書 §6「負値発生時は 0 として表示」「NaN / Infinity に安全にフォールバック」を実現する内部ヘルパ。
+ */
+function safeNum(
+  value: number,
+  options: { min?: number; fallback?: number } = {},
+): number {
+  const { min = 0, fallback = 0 } = options;
+  if (!Number.isFinite(value)) return fallback;
+  if (value < min) return fallback;
+  return value;
+}
+
+/**
+ * `insourcingLevel` が `INSOURCING_LEVELS` の値域に属するか検証し、外れ値は安全側
+ * （`0` = 完全ベンダー依存）にフォールバックする。`as` キャストで上流から不正値が
+ * 流入したケースに備える。
+ */
+function normalizeInsourcingLevel(level: InsourcingLevel): InsourcingLevel {
+  const isValid = INSOURCING_LEVELS.some((entry) => entry.value === level);
+  return isValid ? level : 0;
+}
+
+/**
+ * 計算結果の金額系プロパティを最終クリップする。NaN / Infinity / 負値を 0 に丸める。
+ */
+function clampAmount(amount: number): number {
+  if (!Number.isFinite(amount)) return 0;
+  return Math.max(0, amount);
+}
+
+/**
+ * ROI 診断の中心関数。仕様書 §5 の擬似コードと一致する純粋関数。
+ *
+ * 主要式:
+ * - `insourcingGap = 1 - insourcingLevel`
+ * - `threeYearSavings =
+ *      (monthlyVendorCost * MONTHS_IN_PERIOD
+ *       + repairCost * REPAIRS_PER_YEAR * YEARS_IN_PERIOD)
+ *      * insourcingGap`
+ * - `annualProfitCreation =
+ *      manualWorkerCount * hoursPerDay * daysPerMonth
+ *      * MONTHS_PER_YEAR * hourlyWage`
+ * - `threeYearProfitCreation = annualProfitCreation * YEARS_IN_PERIOD`
+ * - `totalThreeYearImpact = threeYearSavings + threeYearProfitCreation`
+ * - `speedWarning = updateWaitMonths >= SPEED_WARNING_THRESHOLD_MONTHS`
+ *
+ * @example
+ * // 標準値
+ * calculate({
+ *   monthlyVendorCost: 1_000_000,
+ *   repairCost: 500_000,
+ *   manualWorkerCount: 5,
+ *   updateWaitMonths: 4.5,
+ *   insourcingLevel: 0.25,
+ * });
+ * // → { threeYearSavings: 30_375_000, annualProfitCreation: 6_000_000,
+ * //     threeYearProfitCreation: 18_000_000,
+ * //     totalThreeYearImpact: 48_375_000, speedWarning: true,
+ * //     insourcingGap: 0.75 }
+ */
+export function calculate(input: CalculationInput): CalculationOutput {
+  const monthlyVendorCost = safeNum(input.monthlyVendorCost);
+  const repairCost = safeNum(input.repairCost);
+  const manualWorkerCount = safeNum(input.manualWorkerCount);
+  const updateWaitMonths = safeNum(input.updateWaitMonths);
+
+  const hourlyWage = safeNum(input.hourlyWage ?? DEFAULT_HOURLY_WAGE, {
+    fallback: DEFAULT_HOURLY_WAGE,
+  });
+  const hoursPerDay = safeNum(input.hoursPerDay ?? DEFAULT_HOURS_PER_DAY, {
+    fallback: DEFAULT_HOURS_PER_DAY,
+  });
+  const daysPerMonth = safeNum(input.daysPerMonth ?? DEFAULT_DAYS_PER_MONTH, {
+    fallback: DEFAULT_DAYS_PER_MONTH,
+  });
+
+  const insourcingLevel = normalizeInsourcingLevel(input.insourcingLevel);
+  const insourcingGap = 1 - insourcingLevel;
+
+  const rawSavings =
+    monthlyVendorCost * MONTHS_IN_PERIOD +
+    repairCost * REPAIRS_PER_YEAR * YEARS_IN_PERIOD;
+  const threeYearSavings = clampAmount(rawSavings * insourcingGap);
+
+  const annualProfitCreation = clampAmount(
+    manualWorkerCount * hoursPerDay * daysPerMonth * MONTHS_PER_YEAR * hourlyWage,
+  );
+  const threeYearProfitCreation = clampAmount(
+    annualProfitCreation * YEARS_IN_PERIOD,
+  );
+  const totalThreeYearImpact = clampAmount(
+    threeYearSavings + threeYearProfitCreation,
+  );
+
+  return {
+    threeYearSavings,
+    annualProfitCreation,
+    threeYearProfitCreation,
+    totalThreeYearImpact,
+    speedWarning: updateWaitMonths >= SPEED_WARNING_THRESHOLD_MONTHS,
+    insourcingGap,
+  };
+}
+
+/**
+ * 万円表記の数値を円単位に変換する。UI 入力（万円）→ 計算ロジック（円）の単一入口。
+ *
+ * @example
+ * manYenToYen(1);       // → 10_000
+ * manYenToYen(10_000);  // → 100_000_000
+ */
+export function manYenToYen(manYen: number): number {
+  return manYen * YEN_PER_MAN_YEN;
+}
+
+/**
+ * 円単位の数値を万円表記の数値に変換する。表示文字列化は format.ts 側で行う。
+ *
+ * @example
+ * yenToManYen(10_000);       // → 1
+ * yenToManYen(100_000_000);  // → 10_000
+ */
+export function yenToManYen(yen: number): number {
+  return yen / YEN_PER_MAN_YEN;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -49,7 +49,9 @@ export const OKU_THRESHOLD_MAN_YEN = 100_000;
  * `value` から union 型 `InsourcingLevel` を導出する。
  *
  * - `value`: 内製化の進捗（0 = 完全ベンダー依存、1.0 = 完全内製）
- * - `gap`: 1 - value（止血額への乗算係数）
+ * - `gap`: 1 - value（止血額への乗算係数）。UI 表示や説明文用の派生値。
+ *   計算ロジックでは `calculate()` 内で `1 - insourcingLevel` を直接算出するため
+ *   本フィールドは参照していない（仕様書 §4.2）。
  * - `label`: 通常の選択 UI で表示するラベル
  * - `shortLabel`: グラフ凡例など狭い領域での短縮表示用
  *

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,70 @@
+/**
+ * 計算ロジック・フォーマッタで参照する定数群。
+ *
+ * - 仕様: docs/spec/calculation-logic.md §5（固定値・デフォルト値）／§4.1（内製化選択肢）
+ *         docs/spec/result-dashboard.md §9.2（億円表記閾値）
+ *         docs/spec/input-form.md §9.1（万円↔円変換係数）
+ * - 設計: 同じ数値が calculation.ts / format.ts / 後続 InputForm から参照されるため、
+ *         単一の真実の源として本ファイルに集約する。
+ *         INSOURCING_LEVELS は as const 配列からリテラル union 型を導出する
+ *         （仕様書 §10「実行時・型の両面から堅牢化」要件）。
+ */
+
+/** 試算期間（月）。商品コンセプト「3年間の止血」に結合された固定値。 */
+export const MONTHS_IN_PERIOD = 36;
+
+/** 試算年数。`MONTHS_IN_PERIOD / MONTHS_PER_YEAR` と一致する固定値。 */
+export const YEARS_IN_PERIOD = 3;
+
+/** 年あたり改修回数（四半期想定で軽微 1 回を除外した固定値）。 */
+export const REPAIRS_PER_YEAR = 3;
+
+/** 年あたり月数（暦定数）。 */
+export const MONTHS_PER_YEAR = 12;
+
+/** 時給単価デフォルト（円/時）。詳細設定で上書き可。 */
+export const DEFAULT_HOURLY_WAGE = 2_500;
+
+/** 1 日あたり手作業時間デフォルト（時間/日）。詳細設定で上書き可。 */
+export const DEFAULT_HOURS_PER_DAY = 2;
+
+/** 月あたり稼働日数デフォルト（日/月）。詳細設定で上書き可。 */
+export const DEFAULT_DAYS_PER_MONTH = 20;
+
+/** スピード警告発動閾値（月）。`updateWaitMonths >= 3` で警告。 */
+export const SPEED_WARNING_THRESHOLD_MONTHS = 3;
+
+/** 万円 ⇄ 円の換算係数（10,000）。 */
+export const YEN_PER_MAN_YEN = 10_000;
+
+/**
+ * 億円表記切替閾値（万円単位）。
+ * `formatManYenCompact` は万円換算後の値が本値以上のとき「◯億◯万円」表記へ切り替える。
+ * 100,000 万円 = 10 億円（docs/spec/result-dashboard.md §9.2）。
+ */
+export const OKU_THRESHOLD_MAN_YEN = 100_000;
+
+/**
+ * 内製化状況の選択肢。`as const` でリテラル型を維持し、
+ * `value` から union 型 `InsourcingLevel` を導出する。
+ *
+ * - `value`: 内製化の進捗（0 = 完全ベンダー依存、1.0 = 完全内製）
+ * - `gap`: 1 - value（止血額への乗算係数）
+ * - `label`: 通常の選択 UI で表示するラベル
+ * - `shortLabel`: グラフ凡例など狭い領域での短縮表示用
+ *
+ * 仕様: docs/spec/calculation-logic.md §4.1
+ */
+export const INSOURCING_LEVELS = [
+  { value: 0, label: "完全ベンダー依存", shortLabel: "完全依存", gap: 1.0 },
+  { value: 0.25, label: "一部内製", shortLabel: "一部", gap: 0.75 },
+  { value: 0.5, label: "半分内製", shortLabel: "半分", gap: 0.5 },
+  { value: 0.75, label: "大半内製", shortLabel: "大半", gap: 0.25 },
+  { value: 1.0, label: "完全内製", shortLabel: "完全", gap: 0.0 },
+] as const;
+
+/**
+ * 内製化状況のリテラル union 型。
+ * `0 | 0.25 | 0.5 | 0.75 | 1`
+ */
+export type InsourcingLevel = (typeof INSOURCING_LEVELS)[number]["value"];

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -11,7 +11,7 @@
 import { OKU_THRESHOLD_MAN_YEN, YEN_PER_MAN_YEN } from "./constants";
 
 const ZERO_MAN_YEN = "0万円";
-const ZERO_YEN = "0 円";
+const ZERO_YEN = "0円";
 const ZERO_PERCENT = "0%";
 const ZERO_HUMAN = "0 人";
 
@@ -57,12 +57,13 @@ export function formatManYenCompact(yen: number): string {
 }
 
 /**
- * 円単位の値を「1,234,567 円」形式に変換する。デバッグ・PDF 補助表示用。
- * NaN / Infinity / 負値は `"0 円"` を返す。
+ * 円単位の値を「1,234,567円」形式に変換する。デバッグ・PDF 補助表示用。
+ * `formatManYen` と表記を揃えるため通貨単位の前にスペースを入れない。
+ * NaN / Infinity / 負値は `"0円"` を返す。
  */
 export function formatYen(yen: number): string {
   if (!Number.isFinite(yen) || yen < 0) return ZERO_YEN;
-  return `${Math.round(yen).toLocaleString("ja-JP")} 円`;
+  return `${Math.round(yen).toLocaleString("ja-JP")}円`;
 }
 
 /**
@@ -76,7 +77,10 @@ export function formatYen(yen: number): string {
 export function formatPercent(rate: number, fractionDigits = 0): string {
   if (!Number.isFinite(rate) || rate < 0) return ZERO_PERCENT;
   const fixed = (rate * 100).toFixed(fractionDigits);
-  const trimmed = fractionDigits > 0 ? fixed.replace(/\.?0+$/, "") : fixed;
+  // fractionDigits > 0 のとき末尾の不要な 0 と小数点を除去する。
+  // 値が 0 のときは regex が全文字を削除してしまうため、空文字なら "0" にフォールバック。
+  const trimmed =
+    fractionDigits > 0 ? fixed.replace(/\.?0+$/, "") || "0" : fixed;
   return `${trimmed}%`;
 }
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,89 @@
+/**
+ * 数値・通貨・パーセント・人数の表示フォーマッタ群。
+ *
+ * - 仕様: docs/spec/result-dashboard.md §9.1（formatManYen）/ §9.2（formatManYenCompact）
+ *         docs/spec/calculation-logic.md §6（万円四捨五入・ゼロ値はハイフン置換しない）
+ * - 設計: ダッシュボードと PDF で同一フォーマッタを共有する「単一の真実の源」。
+ *         calculation.ts 側でも入力ガードしているが、表示層でも NaN / Infinity / 負値を
+ *         安全側にフォールバックして二重防御する。
+ */
+
+import { OKU_THRESHOLD_MAN_YEN, YEN_PER_MAN_YEN } from "./constants";
+
+const ZERO_MAN_YEN = "0万円";
+const ZERO_YEN = "0 円";
+const ZERO_PERCENT = "0%";
+const ZERO_HUMAN = "0 人";
+
+/**
+ * 円単位の値を「◯◯万円」形式に変換する。万円単位で四捨五入し、3 桁区切り。
+ * NaN / Infinity / 負値は `"0万円"` を返す。
+ *
+ * @example
+ * formatManYen(0);          // → "0万円"
+ * formatManYen(15_000);     // → "2万円"
+ * formatManYen(1_350_000);  // → "135万円"
+ * formatManYen(NaN);        // → "0万円"
+ * formatManYen(-100);       // → "0万円"
+ */
+export function formatManYen(yen: number): string {
+  if (!Number.isFinite(yen) || yen < 0) return ZERO_MAN_YEN;
+  const manYen = Math.round(yen / YEN_PER_MAN_YEN);
+  return `${manYen.toLocaleString("ja-JP")}万円`;
+}
+
+/**
+ * ヒーロー数値専用の大桁対応フォーマッタ。万円換算後の値が
+ * `OKU_THRESHOLD_MAN_YEN`（10 億円相当）以上のとき「◯億◯万円」表記に切り替える。
+ * NaN / Infinity / 負値は `"0万円"` を返す。
+ *
+ * @example
+ * formatManYenCompact(1_350_000);       // → "135万円"
+ * formatManYenCompact(10_000_000_000);  // → "10億円"
+ * formatManYenCompact(10_001_000_000);  // → "10億100万円"
+ */
+export function formatManYenCompact(yen: number): string {
+  if (!Number.isFinite(yen) || yen < 0) return ZERO_MAN_YEN;
+  const manYen = Math.round(yen / YEN_PER_MAN_YEN);
+  if (manYen < OKU_THRESHOLD_MAN_YEN) {
+    return `${manYen.toLocaleString("ja-JP")}万円`;
+  }
+  const oku = Math.floor(manYen / OKU_THRESHOLD_MAN_YEN);
+  const remainder = manYen % OKU_THRESHOLD_MAN_YEN;
+  if (remainder === 0) {
+    return `${oku.toLocaleString("ja-JP")}億円`;
+  }
+  return `${oku.toLocaleString("ja-JP")}億${remainder.toLocaleString("ja-JP")}万円`;
+}
+
+/**
+ * 円単位の値を「1,234,567 円」形式に変換する。デバッグ・PDF 補助表示用。
+ * NaN / Infinity / 負値は `"0 円"` を返す。
+ */
+export function formatYen(yen: number): string {
+  if (!Number.isFinite(yen) || yen < 0) return ZERO_YEN;
+  return `${Math.round(yen).toLocaleString("ja-JP")} 円`;
+}
+
+/**
+ * 比率（0..1）をパーセント表記に変換する。`fractionDigits` で小数桁を制御し、
+ * 末尾の不要なゼロを除去して返す。NaN / Infinity / 負値は `"0%"` を返す。
+ *
+ * @example
+ * formatPercent(0.75);     // → "75%"
+ * formatPercent(0.123, 1); // → "12.3%"
+ */
+export function formatPercent(rate: number, fractionDigits = 0): string {
+  if (!Number.isFinite(rate) || rate < 0) return ZERO_PERCENT;
+  const fixed = (rate * 100).toFixed(fractionDigits);
+  const trimmed = fractionDigits > 0 ? fixed.replace(/\.?0+$/, "") : fixed;
+  return `${trimmed}%`;
+}
+
+/**
+ * 人数を「◯ 人」形式に変換する。負値・NaN・Infinity は `"0 人"`。
+ */
+export function formatHumanCount(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return ZERO_HUMAN;
+  return `${Math.round(n).toLocaleString("ja-JP")} 人`;
+}


### PR DESCRIPTION
## 概要
Issue #38 に対応し、後続の InputForm (#2) / ResultDashboard (#4) / WarningBanner (#5) / PDF 出力 (#6) すべての前提となる計算ロジック・フォーマッタ・定数の共通ユーティリティを `src/lib/` に新規実装します。

## 詳細

### 新規ファイル
- **`src/lib/constants.ts`**
  - `MONTHS_IN_PERIOD` / `YEARS_IN_PERIOD` / `REPAIRS_PER_YEAR` / `MONTHS_PER_YEAR` 等の固定値、`DEFAULT_HOURLY_WAGE` / `DEFAULT_HOURS_PER_DAY` / `DEFAULT_DAYS_PER_MONTH` のデフォルト値（`docs/spec/calculation-logic.md §5` 完全一致）
  - `INSOURCING_LEVELS` を `as const` 配列で公開し、`InsourcingLevel` リテラル union 型を導出（仕様書 §10 推奨事項）
  - `SPEED_WARNING_THRESHOLD_MONTHS = 3` / `OKU_THRESHOLD_MAN_YEN = 100_000` / `YEN_PER_MAN_YEN = 10_000`
- **`src/lib/calculation.ts`**
  - `CalculationInput` / `CalculationOutput` 型定義（仕様書 §5 の `Inputs` / `CalculationResult` に対応、命名は Issue 本文準拠）
  - 純粋関数 `calculate(input)` を実装。仕様書 §5 の擬似コードと一字一句揃えた式
  - **NaN / Infinity / 負値の三段防衛**: 入力時 `safeNum`、出力時 `clampAmount`、不正な `insourcingLevel` は `normalizeInsourcingLevel` で `0` フォールバック
  - 単位変換ヘルパ `manYenToYen` / `yenToManYen` を同ファイルから export（仕様書 `input-form.md §9.1` 命名）
- **`src/lib/format.ts`**
  - `formatManYen` / `formatManYenCompact`（10 億円以上で「◯億◯万円」表記、`docs/spec/result-dashboard.md §9.1–§9.2` 準拠）
  - `formatYen` / `formatPercent` / `formatHumanCount`
  - 表示層でも NaN / Infinity / 負値を `"0万円"` / `"0%"` 等に最終ガード

### 受け入れ条件
- [x] `docs/spec/calculation-logic.md` の全パラメータ・全式を実装
- [x] `CalculationInput` / `CalculationOutput` 型を定義し `any` 不使用
- [x] サンプルケース（最小値・標準値・最大値・完全内製・NaN・Infinity）で期待値どおり動作
- [x] フォーマッタが「円」「万円」「億円」表記を仕様どおりに切替
- [x] `npm run typecheck` / `npm run lint` / `npm run build` すべて成功

### 設計上の考慮点（プランから抜粋）
- 内部計算は **円単位・浮動小数のまま**で保持し、丸めは行わない（仕様書 §6）。表示時の万円丸めは `format.ts` 側に閉じ込める。
- `as const` 配列から `InsourcingLevel` を導出することで、UI 側のセグメントコントロールも同じ配列をループでき、ラベル文言の二重定義を防ぐ。
- NaN / Infinity / 負値ガードを `calculate` 入力 → `calculate` 出力 → `format` 表示の三段で配置。

## 参考
- Closes #38
- 仕様: `docs/spec/calculation-logic.md` / `docs/spec/result-dashboard.md §9` / `docs/spec/input-form.md §9`
- プラン: `working/plans/issue-38-calculation-format-constants-utilities_260501222915.md`

## 注意事項
- 本 PR にはユニットテストは含まれていません（プロジェクトに `jest`/`vitest` 等のテストランナー未導入のため）。テスト基盤導入時に「設計上の考慮点 §F」のサンプルケースを移植する想定です。
- 後続 Issue（#2 / #4 / #5 / #6）はすべて本ユーティリティを依存に持つため、本 PR のマージが先行する必要があります。
