### PR TITLE
feat(hooks): useCountUp フック実装 (#40)

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useCountUp, easeOutCubic } from "./useCountUp";
+export type { UseCountUpOptions } from "./useCountUp";

--- a/src/hooks/useCountUp.ts
+++ b/src/hooks/useCountUp.ts
@@ -1,0 +1,141 @@
+/**
+ * 数値カウントアップアニメーション用カスタムフック。
+ *
+ * - 仕様: docs/spec/result-dashboard.md §6.1（自前 useCountUp / requestAnimationFrame ベース /
+ *         duration 1,200ms / easeOutCubic）/ §6.3（prefers-reduced-motion: reduce 尊重）/
+ *         §6.4（マウント時に 1 回発動・再診断時はリマウントで再発動）
+ * - 設計: requestAnimationFrame ベースの自前実装。補間単位は円（number）で、
+ *         表示時に呼び出し側で formatManYen / formatManYenCompact に渡す（仕様書 §9.1 / §9.2）。
+ *         マウント時は 0 から target へ立ち上げるため初期値を 0 で固定する。
+ * - 依存: 純粋に React hooks のみ（useEffect / useRef / useState）。
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+/** カウンターの標準 duration（ミリ秒）。docs/spec/result-dashboard.md §6.1 で確定。 */
+const DEFAULT_DURATION_MS = 1_200;
+
+/** ease-out cubic。t ∈ [0, 1] を [0, 1] に写像する。 */
+export const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+
+/** prefers-reduced-motion: reduce のメディアクエリ文字列。 */
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+export type UseCountUpOptions = {
+  /** アニメーション持続時間（ミリ秒）。既定 1,200ms。 */
+  duration?: number;
+  /**
+   * 補間に用いるイージング関数。t ∈ [0, 1] を受け、補間係数 ∈ [0, 1] を返す。既定 easeOutCubic。
+   * 毎レンダー新しい関数参照を渡すと再アニメが走るため、安定参照（モジュールスコープ関数 /
+   * useCallback でメモ化したもの）を渡すこと。
+   */
+  easing?: (t: number) => number;
+  /** false でアニメーションを停止し、現在値を保持する。既定 true。 */
+  enabled?: boolean;
+};
+
+/**
+ * `target` 値が変化したとき、現在値から滑らかに補間するアニメーションを返すフック。
+ *
+ * - 初期値は 0（仕様書 §6.4「マウント時に 1 回発動」）。target が 0 のままならアニメは発動せず再レンダーも起きない。
+ * - target 変更時は現在値からの差分で再アニメーション。
+ * - prefers-reduced-motion: reduce のときは即時 target を返し rAF を起動しない。
+ * - enabled=false で停止。再開時はその時点の値から target へ補間を再開。
+ * - アンマウント・依存変更時にクリーンアップ関数で cancelAnimationFrame を実行しメモリリークを防ぐ。
+ *
+ * @param target アニメーションの目標値（円単位）。
+ * @param options duration / easing / enabled のオプション。
+ * @returns 補間中の現在値（円単位の number）。
+ */
+export function useCountUp(
+  target: number,
+  options?: UseCountUpOptions,
+): number {
+  const duration = options?.duration ?? DEFAULT_DURATION_MS;
+  const easingFn = options?.easing ?? easeOutCubic;
+  const enabled = options?.enabled ?? true;
+
+  const [value, setValue] = useState<number>(0);
+  const [reducedMotion, setReducedMotion] = useState<boolean>(false);
+
+  const rafIdRef = useRef<number | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+  const startValueRef = useRef<number>(0);
+  const valueRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(REDUCED_MOTION_QUERY);
+    setReducedMotion(mql.matches);
+    const onChange = (event: MediaQueryListEvent) => {
+      setReducedMotion(event.matches);
+    };
+    mql.addEventListener("change", onChange);
+    return () => {
+      mql.removeEventListener("change", onChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+      return;
+    }
+
+    if (reducedMotion) {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+      if (valueRef.current !== target) {
+        valueRef.current = target;
+        setValue(target);
+      }
+      return;
+    }
+
+    if (valueRef.current === target) {
+      return;
+    }
+
+    if (rafIdRef.current !== null) {
+      cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = null;
+    }
+    startValueRef.current = valueRef.current;
+    startTimeRef.current = null;
+
+    const tick = (now: number) => {
+      startTimeRef.current ??= now;
+      const elapsed = now - startTimeRef.current;
+      const progress = duration <= 0 ? 1 : Math.min(1, elapsed / duration);
+      const eased = easingFn(progress);
+      const interp =
+        startValueRef.current + (target - startValueRef.current) * eased;
+
+      if (progress < 1) {
+        valueRef.current = interp;
+        setValue(interp);
+        rafIdRef.current = requestAnimationFrame(tick);
+      } else {
+        valueRef.current = target;
+        setValue(target);
+        rafIdRef.current = null;
+      }
+    };
+
+    rafIdRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
+  }, [target, duration, easingFn, enabled, reducedMotion]);
+
+  return value;
+}

--- a/src/hooks/useCountUp.ts
+++ b/src/hooks/useCountUp.ts
@@ -16,7 +16,7 @@ import { useEffect, useRef, useState } from "react";
 const DEFAULT_DURATION_MS = 1_200;
 
 /** ease-out cubic。t ∈ [0, 1] を [0, 1] に写像する。 */
-export const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+export const easeOutCubic = (t: number): number => 1 - (1 - t) ** 3;
 
 /** prefers-reduced-motion: reduce のメディアクエリ文字列。 */
 const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
@@ -55,6 +55,7 @@ export function useCountUp(
   const easingFn = options?.easing ?? easeOutCubic;
   const enabled = options?.enabled ?? true;
 
+  // 初期値 0 はマウント時の 0 → target 立ち上げアニメ（仕様書 §6.4）を実現するための固定値。
   const [value, setValue] = useState<number>(0);
   const [reducedMotion, setReducedMotion] = useState<boolean>(false);
 
@@ -77,6 +78,17 @@ export function useCountUp(
   }, []);
 
   useEffect(() => {
+    // target が NaN / Infinity の場合は rAF を起動せず現在値を保持する。
+    // NaN === NaN が常に false となり毎フレーム再アニメが走るのを防ぐためのガード
+    // （表示層 src/lib/format.ts:30 の Number.isFinite 防御方針と整合）。
+    if (!Number.isFinite(target)) {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+      return;
+    }
+
     if (!enabled) {
       if (rafIdRef.current !== null) {
         cancelAnimationFrame(rafIdRef.current);


### PR DESCRIPTION
## 概要
診断結果ダッシュボード（Issue #41 / `ResultDashboard`）で利用するカウントアップアニメーション用のカスタムフック `useCountUp` を実装した。

`requestAnimationFrame` ベースの自前実装で、duration 1,200ms / `easeOutCubic` を既定とする（`docs/spec/result-dashboard.md §6.1`）。

## 詳細
### 新規ファイル
- `src/hooks/useCountUp.ts`
  - シグネチャ: `useCountUp(target: number, options?: { duration?: number; easing?: (t: number) => number; enabled?: boolean }): number`
  - 戻り値は **円単位の補間値（number）**。表示時の `formatManYen` / `formatManYenCompact` への接続は呼び出し側で行う。
  - 初期値は `0` 固定。マウント時に 0 → target へ立ち上がる UX を実現（仕様書 §6.4）。
  - `prefers-reduced-motion: reduce` 検出に `window.matchMedia` を購読し、即時 target を返す。
  - `enabled=false` で停止し、`true` 復帰時はその時点の値から target へ補間を再開。
  - `valueRef.current === target` の差分なし時は rAF を起動せず、無駄な再レンダーを発生させない。
  - アンマウント・依存変更時に `cancelAnimationFrame` でクリーンアップ。
  - 最終フレームで `value = target` を代入し、浮動小数誤差を打ち消す（仕様書 §11 R3）。
- `src/hooks/index.ts`
  - バレル export。`import { useCountUp } from "@/hooks"` で参照可能。

### 受け入れ条件の充足
- [x] target が変化したら現在値から滑らかにカウントアップ／ダウンする
- [x] `prefers-reduced-motion: reduce` のときはアニメーションせず即時 target を返す
- [x] アンマウント時に rAF が確実にキャンセルされ、メモリリークしない
- [x] enabled=false で停止できる
- [x] 0 → 0 など差分なしの場合に無駄な再レンダーを発生させない

## 参考
- Closes #40
- 仕様書: `docs/spec/result-dashboard.md §6.1` / §6.3 / §6.4 / §9.1 / §9.2 / §11 R3
- プランファイル: `working/plans/issue-40-implement-use-count-up-hook_260502095809.md`

## 注意事項
- **テスト未追加**: 本リポジトリには Vitest / Jest 等のテストフレームワークが未導入のため、本 PR ではテストを追加していない。受け入れ条件の検証はコードレビューと、後続 Issue #41 での結合検証（DevTools の Performance パネル / React Profiler 目視確認）で担保する方針。
- **`easing` の参照同一性**: 呼び出し側がインラインで毎レンダー新しい関数を渡すと再アニメが走る。`easeOutCubic` を直接渡すか、`useCallback` で安定化すること（JSDoc に注記済み）。
- **`"use client"` ディレクティブなし**: フック単体には付けず、呼び出し側の Client Component で境界を引く設計。
- **検証**: `npm run typecheck` / `npm run lint` / `npm run build` すべて成功。
