### PR TITLE
feat(calculate): 警告バナー WarningBanner を実装 (#42)

### DIFF
--- a/src/app/calculate/CalculatePageClient.tsx
+++ b/src/app/calculate/CalculatePageClient.tsx
@@ -3,8 +3,10 @@
 import dynamic from "next/dynamic";
 import { useMemo, useState } from "react";
 import { InputForm } from "@/components/calculate/InputForm";
+import { WarningBanner } from "@/components/calculate/WarningBanner";
 import { Button } from "@/components/ui/Button";
 import { calculate, type CalculationInput } from "@/lib/calculation";
+import { buildCriticalOpportunityLossMessage } from "@/lib/messages";
 import type { ResultDashboardProps } from "@/components/calculate/ResultDashboard";
 
 const ResultDashboard = dynamic<ResultDashboardProps>(
@@ -22,6 +24,10 @@ export function CalculatePageClient() {
     [submitted],
   );
   const resultKey = submitted ? JSON.stringify(submitted) : "";
+  // 仕様書 docs/spec/warning-copy.md §4.3.3 の判定フローに準拠。
+  // 完全内製顧客 (insourcingLevel === 1) ではバナー自体を非表示にする。
+  const showWarningBanner =
+    !!submitted && !!result && result.speedWarning && submitted.insourcingLevel !== 1;
 
   return (
     <div className="space-y-8 sm:space-y-12">
@@ -31,6 +37,15 @@ export function CalculatePageClient() {
           key={resultKey}
           result={result}
           insourcingLevel={submitted.insourcingLevel}
+          headerSlot={
+            showWarningBanner ? (
+              <WarningBanner
+                message={buildCriticalOpportunityLossMessage(
+                  result.speedWarningMonthlyLoss,
+                )}
+              />
+            ) : undefined
+          }
           footerSlot={
             <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
               <Button

--- a/src/components/calculate/WarningBanner.tsx
+++ b/src/components/calculate/WarningBanner.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 /**
  * スピード警告バナー（CRITICAL OPPORTUNITY LOSS）の描画コンポーネント。
  *
@@ -8,6 +6,8 @@
  * - 設計: 表示可否（speedWarning && insourcingLevel !== 1）は親（CalculatePageClient）で
  *         判定し、本コンポーネントは「整形済み message を受け取り描画する」純表示層。
  *         null を返す責務は持たない（仕様書 §4.3.3 の判定フローに準拠）。
+ *         フック・副作用・状態を持たないため `"use client"` 指示子は不要。
+ *         サーバーコンポーネント配下からも安全に再利用できる。
  * - アクセシビリティ: `role="alert"` を付与（暗黙に aria-live="assertive"）。
  *         診断ボタン押下直後に DOM に挿入されるため、即時通知が適切。
  * - アニメーション: `motion-safe:animate-fadeIn` で 300ms フェードイン。

--- a/src/components/calculate/WarningBanner.tsx
+++ b/src/components/calculate/WarningBanner.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * スピード警告バナー（CRITICAL OPPORTUNITY LOSS）の描画コンポーネント。
+ *
+ * - 仕様: docs/spec/warning-copy.md §3（フレーズ）/ §6（ビジュアル）/ §9.3（props 型）
+ *         docs/spec/result-dashboard.md §8（バナー UI 骨格）
+ * - 設計: 表示可否（speedWarning && insourcingLevel !== 1）は親（CalculatePageClient）で
+ *         判定し、本コンポーネントは「整形済み message を受け取り描画する」純表示層。
+ *         null を返す責務は持たない（仕様書 §4.3.3 の判定フローに準拠）。
+ * - アクセシビリティ: `role="alert"` を付与（暗黙に aria-live="assertive"）。
+ *         診断ボタン押下直後に DOM に挿入されるため、即時通知が適切。
+ * - アニメーション: `motion-safe:animate-fadeIn` で 300ms フェードイン。
+ *         `prefers-reduced-motion: reduce` 時は Tailwind の motion-safe バリアントが
+ *         自動的にクラス適用を抑止する（仕様書 §6.4）。
+ * - 依存: lucide-react (AlertTriangle) / @/lib/cn / @/lib/messages（型のみ）
+ */
+
+import { AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/cn";
+import type { CriticalOpportunityLossMessage } from "@/lib/messages";
+
+export interface WarningBannerProps {
+  /** `buildCriticalOpportunityLossMessage()` の戻り値をそのまま渡す。 */
+  message: CriticalOpportunityLossMessage;
+  className?: string;
+}
+
+export function WarningBanner({ message, className }: WarningBannerProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-start gap-3 rounded-xl border border-accent bg-accent/10 px-4 py-4 sm:px-5 sm:py-5",
+        "min-h-[64px]",
+        "motion-safe:animate-fadeIn",
+        className,
+      )}
+    >
+      <AlertTriangle
+        aria-hidden="true"
+        className="mt-0.5 h-5 w-5 shrink-0 text-accent"
+      />
+      <div className="flex flex-col gap-1">
+        <p className="text-base font-bold uppercase tracking-warning text-ink sm:text-lg">
+          {message.headline}
+        </p>
+        <p className="text-xs leading-relaxed text-ink/80 sm:text-sm">
+          {message.subtext}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/calculation.ts
+++ b/src/lib/calculation.ts
@@ -47,6 +47,9 @@ export interface CalculationInput {
  *
  * - 金額系プロパティはすべて円単位の浮動小数。表示時に format.ts で万円丸めする。
  * - `speedWarning`: `updateWaitMonths >= 3` で `true`（仕様書 §7）。
+ * - `speedWarningMonthlyLoss`: 警告バナーへ動的差し込みする月額機会損失（円単位）。
+ *   `speedWarning === true` のとき `monthlyVendorCost * insourcingGap`、それ以外は 0
+ *   （docs/spec/warning-copy.md §7.1 / §7.3）。
  * - `insourcingGap`: `1 - insourcingLevel`（0..1）。止血額への乗算係数。
  */
 export interface CalculationOutput {
@@ -55,6 +58,7 @@ export interface CalculationOutput {
   threeYearProfitCreation: number;
   totalThreeYearImpact: number;
   speedWarning: boolean;
+  speedWarningMonthlyLoss: number;
   insourcingGap: number;
 }
 
@@ -154,12 +158,18 @@ export function calculate(input: CalculationInput): CalculationOutput {
     threeYearSavings + threeYearProfitCreation,
   );
 
+  const speedWarning = updateWaitMonths >= SPEED_WARNING_THRESHOLD_MONTHS;
+  const speedWarningMonthlyLoss = speedWarning
+    ? clampAmount(monthlyVendorCost * insourcingGap)
+    : 0;
+
   return {
     threeYearSavings,
     annualProfitCreation,
     threeYearProfitCreation,
     totalThreeYearImpact,
-    speedWarning: updateWaitMonths >= SPEED_WARNING_THRESHOLD_MONTHS,
+    speedWarning,
+    speedWarningMonthlyLoss,
     insourcingGap,
   };
 }

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,0 +1,62 @@
+/**
+ * UI 表示文言を組み立てるテンプレート関数群。
+ *
+ * - 仕様: docs/spec/warning-copy.md §3.1（メインフレーズ）/ §3.3（採用文言）/
+ *         §7.1〜§7.4（動的差し込み・実装契約）/ §9（エクスポート API）
+ * - 設計: 純粋関数のみ。UI / フォーマッタ層に依存しない単一の真実の源。
+ *         将来 i18n を導入する際は本ファイルの戻り値型を維持したまま、
+ *         呼び出し側を i18n キー差し替え可能な構造に置換する想定（§11.4）。
+ * - 単位契約: `monthlyLossYen` は **円単位**で受け取り、関数内で万円換算する。
+ */
+
+import { YEN_PER_MAN_YEN } from "./constants";
+
+/**
+ * スピード警告の英語見出し。仕様書 §3.1 で確定したブランドフレーズ。
+ * 全大文字・不変。
+ */
+export const CRITICAL_OPPORTUNITY_LOSS_HEADLINE = "CRITICAL OPPORTUNITY LOSS";
+
+/** スピード警告バナーへ渡す構造化メッセージ。仕様書 §9.3 の `warningMessage` 型に対応。 */
+export interface CriticalOpportunityLossMessage {
+  headline: string;
+  subtext: string;
+}
+
+/**
+ * スピード警告のサブテキスト本文を組み立てる。仕様書 §7.4 の擬似コードを正本実装。
+ *
+ * - `monthlyLossYen <= 0` のとき: フォールバック文言（仕様書 §3.3 候補 c）。
+ * - それ以外: `Math.round(monthlyLossYen / YEN_PER_MAN_YEN)` で万円換算し、
+ *   `ja-JP` ロケールの 3 桁区切り整数として差し込む（§7.1 / §7.4）。
+ *
+ * @example
+ * buildCriticalOpportunityLossSubtext(1_200_000); // → "現在、月額 120 万円相当の機会損失が発生中"
+ * buildCriticalOpportunityLossSubtext(0);         // → "3ヶ月以上の更新待ちで機会損失が累積中"
+ */
+export function buildCriticalOpportunityLossSubtext(
+  monthlyLossYen: number,
+): string {
+  if (monthlyLossYen <= 0) {
+    return "3ヶ月以上の更新待ちで機会損失が累積中";
+  }
+  const manYen = Math.round(monthlyLossYen / YEN_PER_MAN_YEN);
+  return `現在、月額 ${manYen.toLocaleString("ja-JP")} 万円相当の機会損失が発生中`;
+}
+
+/**
+ * `WarningBanner` の `message` props にそのまま渡せる構造化オブジェクトを組み立てる。
+ * 仕様書 §7.4 / §9.2 の `buildCriticalOpportunityLossMessage` を正本実装。
+ *
+ * 典型的な呼び出し条件は `speedWarning === true && insourcingLevel !== 1`
+ * （仕様書 §4.3.3）。表示可否の判定は呼び出し側（`ResultDashboard` コンテナ）で行い、
+ * 本関数自身は文言生成のみを担当する。
+ */
+export function buildCriticalOpportunityLossMessage(
+  monthlyLossYen: number,
+): CriticalOpportunityLossMessage {
+  return {
+    headline: CRITICAL_OPPORTUNITY_LOSS_HEADLINE,
+    subtext: buildCriticalOpportunityLossSubtext(monthlyLossYen),
+  };
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -38,6 +38,17 @@ const config: Config = {
         // 警告バナー見出し用 (docs/spec/warning-copy.md の 0.05em〜0.08em の中央値)
         warning: "0.06em",
       },
+      keyframes: {
+        // 警告バナー等で使うフェードイン (docs/spec/warning-copy.md §6.4)
+        fadeIn: {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
+        },
+      },
+      animation: {
+        // motion-safe バリアントと組み合わせ、prefers-reduced-motion 時は自動的に無効化される
+        fadeIn: "fadeIn 300ms ease-out both",
+      },
       ringColor: {
         DEFAULT: "#9CAEB8",
       },


### PR DESCRIPTION
## 概要
更新待ち期間が 3 ヶ月以上の場合、結果ダッシュボード上部に「CRITICAL OPPORTUNITY LOSS」警告バナーを表示する。文言・色・タイポ・条件は `docs/spec/warning-copy.md` を正本として実装。

## 詳細
- `src/components/calculate/WarningBanner.tsx` を新規作成
  - `role="alert"`、`AlertTriangle` アイコン、`tracking-warning`（0.06em）の英語見出し + 日本語サブテキスト 2 段構成
  - `motion-safe:animate-fadeIn` で 300ms フェードイン、`prefers-reduced-motion: reduce` 時は CSS 側で自動的に無効化
  - 描画専用コンポーネント。表示可否判定は親側で実施（仕様書 §4.3.3）
- `src/lib/messages.ts` を新規作成
  - `CRITICAL_OPPORTUNITY_LOSS_HEADLINE` 定数
  - `buildCriticalOpportunityLossSubtext(monthlyLossYen)` で `monthlyLossYen <= 0` のフォールバック分岐を実装
  - `buildCriticalOpportunityLossMessage(monthlyLossYen)` で `WarningBanner` の `message` props 用構造体を返却
- `CalculationOutput` に `speedWarningMonthlyLoss: number`（円単位）を追加し、`calculate()` で `speedWarning === true` のとき `monthlyVendorCost * insourcingGap` を算出
- `tailwind.config.ts` に `keyframes.fadeIn` と `animation.fadeIn = "fadeIn 300ms ease-out both"` を追加
- `CalculatePageClient` で `result.speedWarning && submitted.insourcingLevel !== 1` を判定し、`ResultDashboard` の `headerSlot` に `WarningBanner` を差し込み

## 受け入れ条件の対応
- [x] 仕様書（`docs/spec/warning-copy.md`）の文言・条件・優先順をすべて実装（§3.1 / §3.3 / §4 / §5.1 / §6 / §7）
- [x] severity が null（speedWarning false または完全内製）のときバナー DOM を描画しない（親側で headerSlot を渡さない）
- [x] スクリーンリーダーで適切に読み上げられる（`role="alert"` 付与、アイコンは `aria-hidden="true"`）
- [x] コントラスト比 WCAG AA を想定した配色（`text-ink` on `bg-accent/10`）— 実機での実測は手動検証で確認
- [x] reduced-motion 時にアニメーションが無効化される（`motion-safe:` バリアントで CSS 側吸収）

## 検証
- `npx tsc --noEmit`: パス
- `npm run lint`: パス（warning なし）
- `npm run build`: パス（13 ページ生成成功）

## 参考
Closes #42
- 仕様書: `docs/spec/warning-copy.md`
- プラン: `working/plans/issue-42-implement-warning-banner_260502110627.md`

## 注意事項
- `severity` props を採用せず構造化 `message` props を採用（仕様書 §5.1 の「単一 UI + 動的差し込み」方針に準拠）。理由はプラン「設計上の考慮点」参照
- 以下は本 PR スコープ外（仕様書 §11.1 / §11.2 / §13.3 のフォローアップ作業として別 PR で対応）:
  - `docs/spec/calculation-logic.md §5` への `speedWarningMonthlyLoss` 追記
  - `docs/spec/result-dashboard.md §8.2 / §8.3 / §8.5 / §10.3` の追記更新
- マージ後の手動確認（推奨）:
  - VoiceOver / DevTools Accessibility パネルで `role="alert"` の読み上げを確認
  - DevTools Lighthouse で `text-ink/80` のコントラスト比 AA を実測（境界線上のため、AA を割る場合は `text-ink/85` への調整を検討）
  - モバイル/タブレット/デスクトップ各幅で 64〜96px の高さに収まることを目視確認
