### PR TITLE
feat(calculate): PDF レポート出力機能を実装 (#43)

### DIFF
--- a/src/app/calculate/CalculatePageClient.tsx
+++ b/src/app/calculate/CalculatePageClient.tsx
@@ -4,7 +4,6 @@ import dynamic from "next/dynamic";
 import { useMemo, useState } from "react";
 import { InputForm } from "@/components/calculate/InputForm";
 import { WarningBanner } from "@/components/calculate/WarningBanner";
-import { Button } from "@/components/ui/Button";
 import { calculate, type CalculationInput } from "@/lib/calculation";
 import { buildCriticalOpportunityLossMessage } from "@/lib/messages";
 import type { ResultDashboardProps } from "@/components/calculate/ResultDashboard";
@@ -37,6 +36,8 @@ export function CalculatePageClient() {
           key={resultKey}
           result={result}
           insourcingLevel={submitted.insourcingLevel}
+          inputs={submitted}
+          onResetRequest={() => setSubmitted(null)}
           headerSlot={
             showWarningBanner ? (
               <WarningBanner
@@ -45,28 +46,6 @@ export function CalculatePageClient() {
                 )}
               />
             ) : undefined
-          }
-          footerSlot={
-            <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
-              <Button
-                variant="primary"
-                size="lg"
-                type="button"
-                disabled
-                aria-disabled="true"
-                title="PDF ダウンロード機能は Issue #43 で実装予定"
-              >
-                PDF をダウンロード
-              </Button>
-              <Button
-                variant="secondary"
-                size="lg"
-                type="button"
-                onClick={() => setSubmitted(null)}
-              >
-                再診断する
-              </Button>
-            </div>
           }
         />
       ) : null}

--- a/src/components/calculate/PdfDashboard.tsx
+++ b/src/components/calculate/PdfDashboard.tsx
@@ -1,0 +1,558 @@
+"use client";
+
+/**
+ * PDF 生成専用ダッシュボード（A4 縦 1 枚レイアウト）。
+ *
+ * - 仕様: docs/spec/pdf-report.md §3.3（描画責任）/ §5（レイアウト）/ §6（ヘッダー・フッター）/
+ *         §9（Recharts 設定）/ §11.1（JSX 正本）/ §11.5（隠しマウント方針）
+ * - 設計:
+ *   - 画面用 `ResultDashboard` とは別 JSX。指標カードは画面 2 並列／PDF 3 並列で
+ *     差分が確定しており（仕様書 §5.5）、`DashboardView` 抽出は別 Issue として分離する。
+ *   - 親（`ResultDashboard`）が `isGeneratingPdf` の間だけ
+ *     `position: absolute; left: -9999px;` で本コンポーネントをマウントし、
+ *     `forwardRef` 経由で取得した DOM ノードを `generatePdf({ element })` に渡す（§8.4）。
+ *   - 寸法（A4 210×297mm）と `font-family` カスケードはインラインスタイルで明示する。
+ *     Tailwind の任意値だと html2canvas の `getComputedStyle` 解決時にズレる経験則的リスクが
+ *     あるため、PDF レイアウトに関わる寸法・色は inline style を採用。
+ *   - Recharts は `isAnimationActive={false}` を必ず指定（仕様書 §3.3 / §9.1）。
+ *     アニメーション中に html2canvas が描画すると中間状態が PDF に焼きつく。
+ *   - スクリーンリーダーに重複読み上げを避けるため `aria-hidden="true"`。
+ */
+
+import { forwardRef } from "react";
+import {
+  Bar,
+  BarChart,
+  LabelList,
+  Legend,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { AlertTriangle, PiggyBank, Sparkles } from "lucide-react";
+import { formatManYen, formatManYenCompact, formatPercent } from "@/lib/format";
+import {
+  INSOURCING_LEVELS,
+  OKU_THRESHOLD_MAN_YEN,
+  YEN_PER_MAN_YEN,
+  type InsourcingLevel,
+} from "@/lib/constants";
+import type { CalculationInput, CalculationOutput } from "@/lib/calculation";
+import { buildCriticalOpportunityLossMessage } from "@/lib/messages";
+import {
+  PDF_CATEGORY_PLACEHOLDER,
+  PDF_COMPANY_NAME,
+  PDF_CONTACT_TEXT,
+  PDF_DISCLAIMER_TEXT,
+  PDF_LOGO_SRC,
+  PDF_REPORT_TITLE,
+} from "@/lib/pdfConstants";
+
+const A4_WIDTH_MM = 210;
+const A4_HEIGHT_MM = 297;
+const PDF_BAR_HEIGHT_PX = 100;
+
+const ACCENT_HEX = "#9CAEB8";
+const ACCENT_60 = "rgba(156, 174, 184, 0.6)";
+const ACCENT_BG_10 = "rgba(156, 174, 184, 0.10)";
+const INK_HEX = "#72665B";
+const LINE_HEX = "#E5E1DA";
+const WHITE_HEX = "#FFFFFF";
+
+const SAVINGS_LABEL = "3 年間の止血";
+const PROFIT_LABEL = "3 年間の利益創出";
+
+/**
+ * 更新待ち期間の代表値→ラベル変換。`InputForm` の `UPDATE_WAIT_OPTIONS` と同一マッピングを
+ * 仕様書 §5.4 の `(※)` 注記準拠で再定義する。InputForm 側は private 配列のため import 不可。
+ */
+const UPDATE_WAIT_LABELS: Array<{ value: number; label: string }> = [
+  { value: 0.5, label: "すぐ対応（〜1ヶ月）" },
+  { value: 1.5, label: "1〜2ヶ月" },
+  { value: 4.5, label: "3〜6ヶ月" },
+  { value: 9, label: "半年〜1年" },
+  { value: 18, label: "1年以上" },
+];
+
+/** 端末タイムゾーンに依存させず JST 固定で「YYYY-MM-DD HH:mm」を生成。 */
+function formatPdfDateTime(date: Date): string {
+  const parts = new Intl.DateTimeFormat("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+  const get = (type: string) =>
+    parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}`;
+}
+
+function findUpdateWaitLabel(value: number): string {
+  return UPDATE_WAIT_LABELS.find((entry) => entry.value === value)?.label ?? "—";
+}
+
+function findInsourcingLabel(level: InsourcingLevel): string {
+  return INSOURCING_LEVELS.find((entry) => entry.value === level)?.label ?? "—";
+}
+
+export interface PdfDashboardProps {
+  result: CalculationOutput;
+  insourcingLevel: InsourcingLevel;
+  /** UI 入力値（円単位）。PDF 入力サマリー表示に万円換算で利用する。 */
+  inputs: CalculationInput;
+  /** ファイル生成時刻。ヘッダー右端の「生成日時」表示と整合させるため親から注入。 */
+  generatedAt: Date;
+}
+
+interface PdfWarningBannerProps {
+  headline: string;
+  subtext: string;
+}
+
+function PdfWarningBanner({ headline, subtext }: PdfWarningBannerProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "3mm",
+        padding: "3mm 4mm",
+        backgroundColor: ACCENT_BG_10,
+        border: `1px solid ${ACCENT_HEX}`,
+        borderRadius: "1mm",
+        height: "14mm",
+        boxSizing: "border-box",
+      }}
+    >
+      <AlertTriangle
+        aria-hidden="true"
+        width={18}
+        height={18}
+        color={ACCENT_HEX}
+      />
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <span
+          style={{
+            fontSize: "12pt",
+            fontWeight: 700,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+            color: INK_HEX,
+          }}
+        >
+          {headline}
+        </span>
+        <span style={{ fontSize: "10pt", color: INK_HEX }}>{subtext}</span>
+      </div>
+    </div>
+  );
+}
+
+interface MetricCardProps {
+  title: string;
+  value: string;
+  note?: string;
+}
+
+function MetricCard({ title, value, note }: MetricCardProps) {
+  return (
+    <div
+      style={{
+        border: `1px solid ${LINE_HEX}`,
+        borderRadius: "1mm",
+        padding: "6mm 5mm",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "flex-start",
+        gap: "2mm",
+        boxSizing: "border-box",
+      }}
+    >
+      <div style={{ fontSize: "10pt", fontWeight: 500, color: INK_HEX }}>
+        {title}
+      </div>
+      <div style={{ fontSize: "16pt", fontWeight: 700, color: INK_HEX }}>
+        {value}
+      </div>
+      {note ? (
+        <div style={{ fontSize: "8pt", color: INK_HEX, opacity: 0.7 }}>
+          {note}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface SummaryRowProps {
+  label: string;
+  value: string;
+}
+
+function SummaryRow({ label, value }: SummaryRowProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "baseline",
+        padding: "1.5mm 0",
+        borderBottom: `1px dotted ${LINE_HEX}`,
+        fontSize: "10pt",
+        color: INK_HEX,
+      }}
+    >
+      <dt style={{ fontWeight: 500 }}>{label}</dt>
+      <dd style={{ margin: 0, fontWeight: 400 }}>{value}</dd>
+    </div>
+  );
+}
+
+export const PdfDashboard = forwardRef<HTMLDivElement, PdfDashboardProps>(
+  function PdfDashboard(
+    { result, insourcingLevel, inputs, generatedAt },
+    ref,
+  ) {
+    const showWarningBanner = result.speedWarning && insourcingLevel !== 1;
+    const warningMessage = showWarningBanner
+      ? buildCriticalOpportunityLossMessage(result.speedWarningMonthlyLoss)
+      : null;
+
+    const insourcingPercent = formatPercent(insourcingLevel);
+    const isPartiallyInsourced = insourcingLevel > 0 && insourcingLevel < 1;
+
+    const totalManYen = Math.round(result.totalThreeYearImpact / YEN_PER_MAN_YEN);
+    const heroFontSize = totalManYen >= OKU_THRESHOLD_MAN_YEN ? "24pt" : "32pt";
+
+    const monthlyVendorManYen = Math.round(
+      inputs.monthlyVendorCost / YEN_PER_MAN_YEN,
+    );
+    const repairManYen = Math.round(inputs.repairCost / YEN_PER_MAN_YEN);
+    const updateWaitLabel = findUpdateWaitLabel(inputs.updateWaitMonths);
+    const insourcingLabel = findInsourcingLabel(insourcingLevel);
+    const hasAdvancedSettings =
+      inputs.hourlyWage !== undefined ||
+      inputs.hoursPerDay !== undefined ||
+      inputs.daysPerMonth !== undefined;
+    const advancedLabel = hasAdvancedSettings ? "カスタム値あり" : "デフォルト値";
+
+    const chartData = [
+      {
+        label: "3年合計",
+        savings: result.threeYearSavings,
+        profit: result.threeYearProfitCreation,
+      },
+    ];
+
+    return (
+      <div
+        ref={ref}
+        role="document"
+        aria-hidden="true"
+        style={{
+          width: `${A4_WIDTH_MM}mm`,
+          height: `${A4_HEIGHT_MM}mm`,
+          backgroundColor: WHITE_HEX,
+          color: INK_HEX,
+          fontFamily:
+            "var(--font-inter), var(--font-noto-sans-jp), sans-serif",
+          padding: "15mm",
+          boxSizing: "border-box",
+          display: "flex",
+          flexDirection: "column",
+          gap: "4mm",
+        }}
+      >
+        {/* ヘッダー */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            height: "18mm",
+            paddingBottom: "3mm",
+            borderBottom: `1px solid ${LINE_HEX}`,
+            boxSizing: "border-box",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={PDF_LOGO_SRC}
+            alt=""
+            style={{ width: "12mm", height: "12mm" }}
+          />
+          <h1
+            style={{
+              margin: 0,
+              fontSize: "14pt",
+              fontWeight: 700,
+              color: INK_HEX,
+            }}
+          >
+            {PDF_REPORT_TITLE}
+          </h1>
+          <span style={{ fontSize: "10pt", color: INK_HEX, opacity: 0.8 }}>
+            生成日時 {formatPdfDateTime(generatedAt)}
+          </span>
+        </div>
+
+        {/* 警告バナー（条件付き） */}
+        {warningMessage ? (
+          <PdfWarningBanner
+            headline={warningMessage.headline}
+            subtext={warningMessage.subtext}
+          />
+        ) : null}
+
+        {/* ヒーロー（3年間のトータルインパクト） */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "2mm",
+            height: "42mm",
+            boxSizing: "border-box",
+          }}
+        >
+          <div style={{ fontSize: "10pt", color: INK_HEX, opacity: 0.8 }}>
+            3 年間のトータルインパクト
+          </div>
+          <div
+            style={{
+              fontSize: heroFontSize,
+              fontWeight: 700,
+              color: INK_HEX,
+              lineHeight: 1.1,
+            }}
+          >
+            {formatManYenCompact(result.totalThreeYearImpact)}
+          </div>
+          <div style={{ fontSize: "10pt", color: INK_HEX, opacity: 0.6 }}>
+            ※ 試算上の最大値
+          </div>
+        </div>
+
+        {/* 指標カード 3 並列 */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr 1fr",
+            gap: "6mm",
+            height: "34mm",
+            boxSizing: "border-box",
+          }}
+        >
+          <MetricCard
+            title="3 年間の止血"
+            value={formatManYen(result.threeYearSavings)}
+            note={
+              isPartiallyInsourced
+                ? `内製化 ${insourcingPercent} 相当分を除外済み`
+                : undefined
+            }
+          />
+          <MetricCard
+            title="年間の利益創出"
+            value={formatManYen(result.annualProfitCreation)}
+          />
+          <MetricCard
+            title="3 年間の利益創出"
+            value={formatManYen(result.threeYearProfitCreation)}
+          />
+        </div>
+
+        {/* 積み上げ横棒グラフ */}
+        <div style={{ height: "42mm", boxSizing: "border-box" }}>
+          <ResponsiveContainer width="100%" height={PDF_BAR_HEIGHT_PX}>
+            <BarChart
+              data={chartData}
+              layout="vertical"
+              margin={{ top: 8, right: 24, bottom: 8, left: 16 }}
+            >
+              <XAxis
+                type="number"
+                tickFormatter={(value: number) => formatManYen(value)}
+                stroke={ACCENT_HEX}
+              />
+              <YAxis type="category" dataKey="label" hide />
+              <Legend
+                verticalAlign="bottom"
+                content={() => (
+                  <ul
+                    style={{
+                      display: "flex",
+                      justifyContent: "center",
+                      gap: "12mm",
+                      margin: 0,
+                      padding: "2mm 0 0 0",
+                      listStyle: "none",
+                      fontSize: "9pt",
+                      color: INK_HEX,
+                    }}
+                  >
+                    <li
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "1mm",
+                      }}
+                    >
+                      <PiggyBank
+                        aria-hidden="true"
+                        width={12}
+                        height={12}
+                        color={ACCENT_HEX}
+                      />
+                      <span>{SAVINGS_LABEL}</span>
+                      <span style={{ fontWeight: 600 }}>
+                        {formatManYen(result.threeYearSavings)}
+                      </span>
+                    </li>
+                    <li
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "1mm",
+                      }}
+                    >
+                      <Sparkles
+                        aria-hidden="true"
+                        width={12}
+                        height={12}
+                        color={ACCENT_60}
+                      />
+                      <span>{PROFIT_LABEL}</span>
+                      <span style={{ fontWeight: 600 }}>
+                        {formatManYen(result.threeYearProfitCreation)}
+                      </span>
+                    </li>
+                  </ul>
+                )}
+              />
+              <Bar
+                dataKey="savings"
+                name={SAVINGS_LABEL}
+                stackId="impact"
+                fill={ACCENT_HEX}
+                radius={[2, 0, 0, 2]}
+                isAnimationActive={false}
+              >
+                <LabelList
+                  dataKey="savings"
+                  position="insideLeft"
+                  formatter={(value: number) => formatManYen(value)}
+                  style={{ fill: WHITE_HEX, fontSize: 10, fontWeight: 600 }}
+                />
+              </Bar>
+              <Bar
+                dataKey="profit"
+                name={PROFIT_LABEL}
+                stackId="impact"
+                fill={ACCENT_60}
+                radius={[0, 2, 2, 0]}
+                isAnimationActive={false}
+              >
+                <LabelList
+                  dataKey="profit"
+                  position="insideRight"
+                  formatter={(value: number) => formatManYen(value)}
+                  style={{ fill: INK_HEX, fontSize: 10, fontWeight: 600 }}
+                />
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* カテゴリ訴求（プレースホルダ） */}
+        <div
+          style={{
+            height: "14mm",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: "11pt",
+            color: INK_HEX,
+            backgroundColor: ACCENT_BG_10,
+            borderRadius: "1mm",
+            boxSizing: "border-box",
+            padding: "0 6mm",
+            textAlign: "center",
+          }}
+        >
+          {PDF_CATEGORY_PLACEHOLDER}
+        </div>
+
+        {/* 入力サマリー */}
+        <dl
+          style={{
+            margin: 0,
+            padding: 0,
+            height: "40mm",
+            boxSizing: "border-box",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "flex-start",
+          }}
+        >
+          <SummaryRow
+            label="月額ベンダー費用"
+            value={`${monthlyVendorManYen.toLocaleString("ja-JP")} 万円／月`}
+          />
+          <SummaryRow
+            label="単発改修費用"
+            value={`${repairManYen.toLocaleString("ja-JP")} 万円／回`}
+          />
+          <SummaryRow
+            label="手作業人数"
+            value={`${Math.round(inputs.manualWorkerCount).toLocaleString("ja-JP")} 人`}
+          />
+          <SummaryRow label="更新待ち期間" value={updateWaitLabel} />
+          <SummaryRow label="内製化状況" value={insourcingLabel} />
+          <SummaryRow label="詳細設定" value={advancedLabel} />
+        </dl>
+
+        {/* 免責 */}
+        <p
+          style={{
+            margin: 0,
+            fontSize: "8pt",
+            color: INK_HEX,
+            opacity: 0.7,
+            height: "8mm",
+            boxSizing: "border-box",
+          }}
+        >
+          {PDF_DISCLAIMER_TEXT}
+        </p>
+
+        {/* スペーサー（フッターを下端に押し出す） */}
+        <div style={{ flex: 1 }} />
+
+        {/* フッター */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            height: "13mm",
+            paddingTop: "3mm",
+            borderTop: `1px solid ${LINE_HEX}`,
+            boxSizing: "border-box",
+            fontSize: "9pt",
+            color: INK_HEX,
+          }}
+        >
+          <span style={{ fontSize: "10pt", fontWeight: 500 }}>
+            {PDF_COMPANY_NAME}
+          </span>
+          <span>{PDF_CONTACT_TEXT}</span>
+          <span>1 / 1</span>
+        </div>
+      </div>
+    );
+  },
+);

--- a/src/components/calculate/PdfDashboard.tsx
+++ b/src/components/calculate/PdfDashboard.tsx
@@ -65,14 +65,17 @@ const PROFIT_LABEL = "3 年間の利益創出";
 /**
  * 更新待ち期間の代表値→ラベル変換。`InputForm` の `UPDATE_WAIT_OPTIONS` と同一マッピングを
  * 仕様書 §5.4 の `(※)` 注記準拠で再定義する。InputForm 側は private 配列のため import 不可。
+ *
+ * `as const` で literal の組を保つことで、`InputForm` 側の値が変わった際に手書き複製の
+ * 反映漏れを TS エラーとして拾いやすくする（共有型の正式統一は別 Issue で対応）。
  */
-const UPDATE_WAIT_LABELS: Array<{ value: number; label: string }> = [
+const UPDATE_WAIT_LABELS = [
   { value: 0.5, label: "すぐ対応（〜1ヶ月）" },
   { value: 1.5, label: "1〜2ヶ月" },
   { value: 4.5, label: "3〜6ヶ月" },
   { value: 9, label: "半年〜1年" },
   { value: 18, label: "1年以上" },
-];
+] as const;
 
 /** 端末タイムゾーンに依存させず JST 固定で「YYYY-MM-DD HH:mm」を生成。 */
 function formatPdfDateTime(date: Date): string {
@@ -444,7 +447,13 @@ export const PdfDashboard = forwardRef<HTMLDivElement, PdfDashboardProps>(
                 <LabelList
                   dataKey="savings"
                   position="insideLeft"
-                  formatter={(value: number) => formatManYen(value)}
+                  formatter={(value: number) =>
+                    value <
+                    (result.threeYearSavings + result.threeYearProfitCreation) *
+                      0.05
+                      ? ""
+                      : formatManYen(value)
+                  }
                   style={{ fill: WHITE_HEX, fontSize: 10, fontWeight: 600 }}
                 />
               </Bar>
@@ -459,7 +468,17 @@ export const PdfDashboard = forwardRef<HTMLDivElement, PdfDashboardProps>(
                 <LabelList
                   dataKey="profit"
                   position="insideRight"
-                  formatter={(value: number) => formatManYen(value)}
+                  formatter={(value: number) =>
+                    // 桁爆発時に隣接ラベルと衝突する場合や、profit が savings に対して
+                    // 極端に小さく insideRight に収まらない場合は描画を抑制する。
+                    // 比率閾値はバー幅の概算（A4 約 180mm + scale=2）で「ラベルが視認可能」
+                    // と判断できる下限として 5% を採用。
+                    value <
+                    (result.threeYearSavings + result.threeYearProfitCreation) *
+                      0.05
+                      ? ""
+                      : formatManYen(value)
+                  }
                   style={{ fill: INK_HEX, fontSize: 10, fontWeight: 600 }}
                 />
               </Bar>
@@ -508,7 +527,11 @@ export const PdfDashboard = forwardRef<HTMLDivElement, PdfDashboardProps>(
           />
           <SummaryRow
             label="手作業人数"
-            value={`${Math.round(inputs.manualWorkerCount).toLocaleString("ja-JP")} 人`}
+            value={`${Math.round(
+              // `InputForm` 側で整数バリデーション済みだが、`CalculationInput.manualWorkerCount`
+              // の型は `number` のため、想定外の小数値が表示に漏れないよう PDF 表示層でも防御的に丸める。
+              inputs.manualWorkerCount,
+            ).toLocaleString("ja-JP")} 人`}
           />
           <SummaryRow label="更新待ち期間" value={updateWaitLabel} />
           <SummaryRow label="内製化状況" value={insourcingLabel} />

--- a/src/components/calculate/ResultDashboard.tsx
+++ b/src/components/calculate/ResultDashboard.tsx
@@ -5,14 +5,18 @@
  *
  * - 仕様: docs/spec/result-dashboard.md §3〜§9（ヒーロー / 補助カード / 積み上げ横棒 /
  *         §6 アニメーション方針 / §9 表示単位）／docs/design-tokens.md §2〜§5
+ *         docs/spec/pdf-report.md §8（生成フロー）/ §11.4（コンテナ責務）
  * - 設計: 仕様書 §10.2 の「描画層 (`DashboardView`) / 画面コンテナ (`ResultDashboard`) /
  *         PDF 用ラッパ (`PdfDashboard`)」3 層分離は本実装では本ファイル 1 つに同居させた
- *         暫定構造で運用する。`PdfDashboard` 切り出しは PDF 実装（Issue #43）着手時に
- *         本ファイルから `DashboardView` を抽出するかたちで対応する想定。
+ *         暫定構造で運用する。`DashboardView` 抽出は別 Issue として申し送り、
+ *         本 Issue（#43）では `PdfDashboard` を独立コンポーネントとして並置する。
  *         Recharts は SSR 段階で `ResizeObserver` 等のブラウザ API に依存するため、
  *         呼び出し側（CalculatePageClient）で `next/dynamic({ ssr: false })` を経由する。
+ *         PDF 生成中のみ `PdfDashboard` を `position: absolute; left: -9999px` で
+ *         隠しマウントし、`forwardRef` 経由で取得した DOM ノードを `generatePdf()` に渡す。
  * - 依存: recharts（v2 系）／lucide-react／@/hooks/useCountUp／@/lib/format／
- *         @/lib/calculation／@/lib/constants／@/components/ui/Card／@/lib/cn
+ *         @/lib/calculation／@/lib/constants／@/components/ui/Card／@/lib/cn／
+ *         @/lib/pdf（dynamic import 内蔵）／@/lib/pdfFilename／./PdfDashboard
  * - トークン追従: `ACCENT_HEX` / `ACCENT_60` / `TOOLTIP_CURSOR_FILL` は
  *         `tailwind.config.ts` の `accent` (#9CAEB8) と同値の手書き定数。
  *         `docs/design-tokens.md §2` の「CSS 変数を挟まない」方針に沿った意図的設計のため、
@@ -22,7 +26,14 @@
  *         凡例は「最終的に到達する値」を示すラベルとして役割が明確なため意図的に静的化。
  */
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   Bar,
   BarChart,
@@ -32,13 +43,17 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { PiggyBank, Sparkles } from "lucide-react";
+import { Loader2, PiggyBank, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { cn } from "@/lib/cn";
 import { useCountUp } from "@/hooks/useCountUp";
 import { formatManYen, formatManYenCompact, formatPercent } from "@/lib/format";
 import type { InsourcingLevel } from "@/lib/constants";
-import type { CalculationOutput } from "@/lib/calculation";
+import type { CalculationInput, CalculationOutput } from "@/lib/calculation";
+import { generatePdf } from "@/lib/pdf";
+import { buildPdfFilename } from "@/lib/pdfFilename";
+import { PdfDashboard } from "./PdfDashboard";
 
 const ACCENT_HEX = "#9CAEB8";
 const ACCENT_60 = "rgba(156, 174, 184, 0.6)";
@@ -83,28 +98,80 @@ export type ResultDashboardProps = {
   /** 内製化注記（仕様書 §3.3）の表示制御に使用。 */
   insourcingLevel: InsourcingLevel;
   /**
+   * フォーム入力値（円単位）。`PdfDashboard` の入力サマリー表示に使用する
+   * （仕様書 docs/spec/pdf-report.md §5.4）。
+   */
+  inputs: CalculationInput;
+  /**
    * 警告バナー差し込み口（仕様書 §3.4 / §8）。
    * 親が WarningBanner（Issue #42）を組み立てて渡す。
    * undefined の場合はバナー領域を描画しない。
    */
   headerSlot?: ReactNode;
   /**
-   * フッター差し込み口（仕様書 §3.4 / Issue #43 連携）。
-   * 親が PDF ダウンロード／再診断ボタンを組み立てて渡す。
+   * 「再診断する」ボタン押下時のコールバック（仕様書 docs/spec/pdf-report.md §11.4）。
+   * 親が `setSubmitted(null)` 等で診断状態のリセットを実行する想定。
+   * 未指定の場合は再診断ボタンを描画しない。
    */
-  footerSlot?: ReactNode;
+  onResetRequest?: () => void;
   className?: string;
 };
 
 export function ResultDashboard({
   result,
   insourcingLevel,
+  inputs,
   headerSlot,
-  footerSlot,
+  onResetRequest,
   className,
 }: ResultDashboardProps) {
   const reducedMotion = useReducedMotion();
   const isMobile = useIsMobile();
+
+  const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
+  const [pdfError, setPdfError] = useState<string | null>(null);
+  const pdfDashboardRef = useRef<HTMLDivElement | null>(null);
+  const generatedAtRef = useRef<Date | null>(null);
+
+  // 仕様書 docs/spec/pdf-report.md §8.3: エラーメッセージは 5 秒で自動消去。
+  useEffect(() => {
+    if (!pdfError) return;
+    const tid = setTimeout(() => setPdfError(null), 5000);
+    return () => clearTimeout(tid);
+  }, [pdfError]);
+
+  const handleDownloadPdf = useCallback(async () => {
+    if (isGeneratingPdf) return;
+    setPdfError(null);
+    const generatedAt = new Date();
+    generatedAtRef.current = generatedAt;
+    setIsGeneratingPdf(true);
+    try {
+      // 仕様書 §8.1: requestAnimationFrame 2 回分待機（DOM レイアウト確定 + フォント解決）。
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => resolve()),
+        ),
+      );
+      const element = pdfDashboardRef.current;
+      if (!element) {
+        throw new Error("PdfDashboard element is not mounted");
+      }
+      await generatePdf({
+        element,
+        filename: buildPdfFilename(generatedAt),
+      });
+    } catch (err) {
+      // 仕様書 §8.3: コンソールに詳細を出力しつつ、UI には固定文言を表示。
+      console.error("[PDF generation failed]", err);
+      setPdfError(
+        "PDFの生成に失敗しました。ページを再読み込みして再度お試しください。",
+      );
+    } finally {
+      setIsGeneratingPdf(false);
+      generatedAtRef.current = null;
+    }
+  }, [isGeneratingPdf]);
 
   const animatedSavings = useCountUp(result.threeYearSavings);
   const animatedAnnualProfit = useCountUp(result.annualProfitCreation);
@@ -280,7 +347,65 @@ export function ResultDashboard({
         ) : null}
       </Card>
 
-      {footerSlot ? <div>{footerSlot}</div> : null}
+      <div className="flex flex-col items-center gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <Button
+            variant="primary"
+            size="lg"
+            type="button"
+            onClick={handleDownloadPdf}
+            disabled={isGeneratingPdf}
+            aria-busy={isGeneratingPdf}
+          >
+            {isGeneratingPdf ? (
+              <>
+                <Loader2
+                  aria-hidden="true"
+                  className="h-4 w-4 animate-spin"
+                />
+                <span>PDF生成中…</span>
+              </>
+            ) : (
+              <span>PDF をダウンロード</span>
+            )}
+          </Button>
+          {onResetRequest ? (
+            <Button
+              variant="secondary"
+              size="lg"
+              type="button"
+              onClick={onResetRequest}
+            >
+              再診断する
+            </Button>
+          ) : null}
+        </div>
+        {pdfError ? (
+          <p role="alert" className="text-sm text-[#B45656]">
+            {pdfError}
+          </p>
+        ) : null}
+      </div>
+
+      {isGeneratingPdf ? (
+        <div
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            left: "-9999px",
+            top: 0,
+            pointerEvents: "none",
+          }}
+        >
+          <PdfDashboard
+            ref={pdfDashboardRef}
+            result={result}
+            insourcingLevel={insourcingLevel}
+            inputs={inputs}
+            generatedAt={generatedAtRef.current ?? new Date()}
+          />
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/components/calculate/ResultDashboard.tsx
+++ b/src/components/calculate/ResultDashboard.tsx
@@ -132,6 +132,9 @@ export function ResultDashboard({
   const [pdfError, setPdfError] = useState<string | null>(null);
   const pdfDashboardRef = useRef<HTMLDivElement | null>(null);
   const generatedAtRef = useRef<Date | null>(null);
+  // 早期 return 用に最新フラグを ref で保持し、`useCallback` の deps を空にして
+  // ハンドラ参照を安定させる（`<Button onClick>` の不要な props 変化を抑制）。
+  const isGeneratingPdfRef = useRef(false);
 
   // 仕様書 docs/spec/pdf-report.md §8.3: エラーメッセージは 5 秒で自動消去。
   useEffect(() => {
@@ -141,7 +144,8 @@ export function ResultDashboard({
   }, [pdfError]);
 
   const handleDownloadPdf = useCallback(async () => {
-    if (isGeneratingPdf) return;
+    if (isGeneratingPdfRef.current) return;
+    isGeneratingPdfRef.current = true;
     setPdfError(null);
     const generatedAt = new Date();
     generatedAtRef.current = generatedAt;
@@ -170,8 +174,9 @@ export function ResultDashboard({
     } finally {
       setIsGeneratingPdf(false);
       generatedAtRef.current = null;
+      isGeneratingPdfRef.current = false;
     }
-  }, [isGeneratingPdf]);
+  }, []);
 
   const animatedSavings = useCountUp(result.threeYearSavings);
   const animatedAnnualProfit = useCountUp(result.annualProfitCreation);

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -1,0 +1,61 @@
+/**
+ * PDF 生成ユーティリティ（html2canvas + jsPDF を dynamic import）。
+ *
+ * - 仕様: docs/spec/pdf-report.md §3.1（html2canvas 主体 + jsPDF 画像貼付）/
+ *         §3.2（html2canvas オプション固定）/ §11.2（関数シグネチャ正本）
+ * - 脆弱性方針: docs/security/jspdf-vulnerabilities.md §2.1〜§2.3 / §7。
+ *
+ *   実装契約（レビューチェックリスト）:
+ *     1. `pdf.html(...)` は **絶対に呼び出してはならない**（dompurify 系 7 件の到達不能判定の前提）。
+ *     2. `addImage` の `imgData` は **html2canvas が生成した dataURL のみ** を渡す。
+ *        ユーザー入力や外部 URL は混入させない。
+ *     3. `pdf.save(filename)` の `filename` には **`buildPdfFilename()` の戻り値以外を渡さない**
+ *        （Path Traversal 到達不能判定の前提）。
+ *
+ * - 性能設計: 仕様書 §10.1〜§10.2。`html2canvas` / `jspdf` を本ファイル内で dynamic import
+ *         することで、PDF 生成ボタンが押されるまで両ライブラリ（合計 ≈ 385KB）を
+ *         初回 LCP の経路から外す。
+ * - エラーハンドリング: 内部では try/catch しない。失敗は呼び出し側
+ *         （`ResultDashboard.handleDownloadPdf`）の try/catch で捕捉する責務分離。
+ */
+
+/** A4 縦幅（mm）。jsPDF の単位 `"mm"` で `addImage` の x/y/width/height に使用。 */
+const A4_WIDTH_MM = 210;
+/** A4 縦長（mm）。 */
+const A4_HEIGHT_MM = 297;
+/** html2canvas の `scale` 固定値（仕様書 §3.2）。Retina 相当のラスタ解像度を担保する。 */
+const HTML2CANVAS_SCALE = 2;
+
+export interface GeneratePdfOptions {
+  /** PDF 化する DOM ノード。`PdfDashboard` の `forwardRef` から取得した HTMLElement を渡す。 */
+  element: HTMLElement;
+  /**
+   * 保存ファイル名。`buildPdfFilename()` の戻り値以外を渡してはならない
+   * （docs/security/jspdf-vulnerabilities.md §2.1）。
+   */
+  filename: string;
+}
+
+/**
+ * 渡された DOM を html2canvas で PNG 化し、A4 1 枚の PDF として保存する。
+ *
+ * - 戻り値: `Promise<void>`。`pdf.save()` 内部完結のため Blob は返さない
+ *           （仕様書 §11.2 / 脆弱性方針 §2.1 のレビュー粒度を維持するため）。
+ */
+export async function generatePdf(options: GeneratePdfOptions): Promise<void> {
+  const [{ default: html2canvas }, { default: JsPDF }] = await Promise.all([
+    import("html2canvas"),
+    import("jspdf"),
+  ]);
+
+  const canvas = await html2canvas(options.element, {
+    scale: HTML2CANVAS_SCALE,
+    useCORS: false,
+    backgroundColor: "#ffffff",
+  });
+  const imgData = canvas.toDataURL("image/png");
+
+  const pdf = new JsPDF("p", "mm", "a4");
+  pdf.addImage(imgData, "PNG", 0, 0, A4_WIDTH_MM, A4_HEIGHT_MM);
+  pdf.save(options.filename);
+}

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -43,7 +43,10 @@ export interface GeneratePdfOptions {
  *           （仕様書 §11.2 / 脆弱性方針 §2.1 のレビュー粒度を維持するため）。
  */
 export async function generatePdf(options: GeneratePdfOptions): Promise<void> {
-  const [{ default: html2canvas }, { default: JsPDF }] = await Promise.all([
+  // jsPDF はライブラリ慣習で先頭小文字のクラス名 `jsPDF` を採用しているため、
+  // ローカル変数名もそれに揃える（grep 時の一致精度のため）。
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const [{ default: html2canvas }, { default: jsPDF }] = await Promise.all([
     import("html2canvas"),
     import("jspdf"),
   ]);
@@ -55,7 +58,7 @@ export async function generatePdf(options: GeneratePdfOptions): Promise<void> {
   });
   const imgData = canvas.toDataURL("image/png");
 
-  const pdf = new JsPDF("p", "mm", "a4");
+  const pdf = new jsPDF("p", "mm", "a4");
   pdf.addImage(imgData, "PNG", 0, 0, A4_WIDTH_MM, A4_HEIGHT_MM);
   pdf.save(options.filename);
 }

--- a/src/lib/pdfConstants.ts
+++ b/src/lib/pdfConstants.ts
@@ -1,0 +1,44 @@
+/**
+ * PDF レポート出力で参照する静的定数群（連絡先・ロゴ・固定文言）。
+ *
+ * - 仕様: docs/spec/pdf-report.md §6.1 / §6.2 / §6.4 / §13.5 / §13.6
+ * - 設計: 「運用で差し替え可能な値」を `PdfDashboard` の JSX から切り離して集約する。
+ *         ロゴパス（`PDF_LOGO_SRC`）は `next.config.mjs` の `output: "export"` 静的配信
+ *         に乗るため `public/` 配下からの絶対パスで指定する。
+ *         連絡先・カテゴリ訴求文言は仕様書 §13.5 / §13.6 で「将来確定」扱いとなっており、
+ *         本ファイルの定数値を差し替えるだけで運用に追従できるよう独立させている。
+ */
+
+/** PDF フッター左端に表示する社名（仕様書 §6.2）。 */
+export const PDF_COMPANY_NAME = "株式会社ねこにまたたび";
+
+/**
+ * PDF フッター中央に表示する連絡先（仕様書 §6.2 / §13.5）。
+ *
+ * Issue #14（アクセス解析）または別運用 Issue で正式値が確定するまでの **暫定値**。
+ * 誤配信防止のため `example` ドメインを使用している。確定後はここを差し替える。
+ */
+export const PDF_CONTACT_TEXT = "contact@nekonimatatabi.example";
+
+/** PDF ヘッダー中央に表示するレポートタイトル（仕様書 §6.1）。 */
+export const PDF_REPORT_TITLE = "ROI診断結果レポート";
+
+/**
+ * PDF ヘッダー左端に描画するロゴの静的パス（仕様書 §6.4）。
+ * `public/brand/logo-pdf.svg` を `next.config.mjs` の `output: "export"` でそのまま静的配信。
+ */
+export const PDF_LOGO_SRC = "/brand/logo-pdf.svg";
+
+/**
+ * PDF 下部の免責文言（仕様書 §5.4 ASCII ワイヤー / docs/spec/calculation-logic.md §6.1）。
+ * A4 1 枚に収めるため簡潔に整形する。
+ */
+export const PDF_DISCLAIMER_TEXT =
+  "本試算は入力値に基づく理論上の最大値であり、実際の効果を保証するものではありません。";
+
+/**
+ * カテゴリ訴求文言のプレースホルダ（仕様書 §13.6）。
+ * Issue #1 の将来拡張で確定するまでの仮文字列。差し替え時はここを更新する。
+ */
+export const PDF_CATEGORY_PLACEHOLDER =
+  "ベンダー依存からの脱却で、IT コストを成長投資へ。";

--- a/src/lib/pdfFilename.ts
+++ b/src/lib/pdfFilename.ts
@@ -1,0 +1,30 @@
+/**
+ * PDF ダウンロード時のファイル名を組み立てるユーティリティ。
+ *
+ * - 仕様: docs/spec/pdf-report.md §7.1（命名規則 `matatabi-roi-{YYYYMMDD}-{HHmm}.pdf`）/
+ *         §11.3（疑似コード正本）
+ * - 脆弱性方針: docs/security/jspdf-vulnerabilities.md §2.1（Path Traversal 到達不能判定）
+ *         に従い、**ユーザー入力を一切混入させず**、`Intl.DateTimeFormat("ja-JP",
+ *         { timeZone: "Asia/Tokyo" })` の `formatToParts` から抽出した数値文字列のみで
+ *         ファイル名を構成する。grep でレビューしやすい単純構造を維持する。
+ * - JST 固定: 端末タイムゾーンに依存させないため `timeZone: "Asia/Tokyo"` を明示。
+ *
+ * @example
+ * buildPdfFilename(new Date("2026-04-23T15:30:00+09:00")); // → "matatabi-roi-20260423-1530.pdf"
+ */
+export function buildPdfFilename(now: Date = new Date()): string {
+  const parts = new Intl.DateTimeFormat("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(now);
+  const get = (type: string) =>
+    parts.find((p) => p.type === type)?.value ?? "";
+  const ymd = `${get("year")}${get("month")}${get("day")}`;
+  const hm = `${get("hour")}${get("minute")}`;
+  return `matatabi-roi-${ymd}-${hm}.pdf`;
+}


### PR DESCRIPTION
## 概要

Issue #43 の PDF レポート出力機能を実装。診断結果を A4 1 枚の PDF として保存できるようにする。

- `PdfDashboard` を新規作成し A4 縦レイアウト（ヘッダー / 警告バナー / ヒーロー / 指標カード 3 並列 / 積み上げ横棒グラフ / カテゴリ訴求 / 入力サマリー / 免責 / フッター）を専用 JSX で構築
- `lib/pdf.ts` で html2canvas + jsPDF を dynamic import 化し、初回 LCP 経路から ≈ 530KB を分離
- `lib/pdfFilename.ts` で `Intl.DateTimeFormat("ja-JP", { timeZone: "Asia/Tokyo" })` ベースの `matatabi-roi-{YYYYMMDD}-{HHmm}.pdf` 命名を実装

## 詳細

### 新規ファイル
- `src/lib/pdfConstants.ts`: 連絡先・ロゴ・固定文言を集約。連絡先 `contact@nekonimatatabi.example` は仕様書 §13.5 に従う**暫定値**（Issue #14 等で正式値が確定したら差し替え）。
- `src/lib/pdfFilename.ts`: ファイル名は `Intl.DateTimeFormat` の `formatToParts` から数値文字列のみ抽出し、ユーザー入力を一切混入させない（`docs/security/jspdf-vulnerabilities.md §2.1` の Path Traversal 到達不能判定を維持）。
- `src/lib/pdf.ts`: `generatePdf({ element, filename })` は `pdf.html()` を**呼ばない** / `addImage` の `imgData` は html2canvas dataURL のみ / `pdf.save()` の `filename` は `buildPdfFilename()` の戻り値以外を渡さない、の 3 点を JSDoc 契約として明示。
- `src/components/calculate/PdfDashboard.tsx`: `forwardRef<HTMLDivElement, PdfDashboardProps>`。Recharts は `isAnimationActive={false}` 固定。寸法・色は inline style で明示し html2canvas の `getComputedStyle` 解決ズレを回避。

### 変更ファイル
- `src/components/calculate/ResultDashboard.tsx`: `inputs` / `onResetRequest` props を追加、`footerSlot` を撤廃。状態 `isGeneratingPdf` / `pdfError` と `handleDownloadPdf` を内部化。`isGeneratingPdf === true` の間のみ `position: absolute; left: -9999px` で `<PdfDashboard>` を隠しマウント。`requestAnimationFrame` 2 回分待機（仕様書 §8.1）。エラー文言は 5 秒で自動消去（§8.3）。
- `src/app/calculate/CalculatePageClient.tsx`: `footerSlot` 撤廃に合わせて PDF / 再診断ボタンの組み立てを `ResultDashboard` 内部へ移管。`inputs={submitted}` と `onResetRequest={() => setSubmitted(null)}` を渡すだけに整理。`Button` import が不要になったため削除。

### 設計判断
- **`generatePdf` のシグネチャ**: Issue 本文の `(input, output) => Promise<Blob>` ではなく、仕様書 §11.2 の `({ element, filename }) => Promise<void>` を採用。`pdf.save()` を関数内部で完結させることで、レビュー時の脆弱性チェック粒度（filename の出所）を維持できる。
- **`DashboardView` 抽出は本 Issue 範囲外**: 指標カード数が画面 2 並列 / PDF 3 並列で異なる（仕様書 §5.5）ため、抽出の便益は限定的。`PdfDashboard` 内に独立 JSX を持たせる方針とし、抽出は別 Issue へ申し送り。
- **`next/font/local` 移行は別 Issue**: 現状の `next/font/google` を継続。Next.js のビルド時にローカルバンドル化される挙動でランタイム CDN 依存はないため、本 Issue では subset 化を含めない。

## 参考

- Closes #43
- 仕様: `docs/spec/pdf-report.md`
- 脆弱性方針: `docs/security/jspdf-vulnerabilities.md`
- プラン: `working/plans/issue-43-implement-pdf-report-output_260502120428.md`

## 注意事項

### 実装契約（脆弱性方針 §7 のレビューチェックリスト）
- [x] `pdf.html(...)` / `jsPDF.prototype.html` の呼び出しが 0 件（grep で確認済み）
- [x] `pdf.save(...)` の引数が `options.filename`（= `buildPdfFilename()` 戻り値）のみ
- [x] `addImage(...)` の `imgData` が `canvas.toDataURL("image/png")` の戻り値のみ
- [x] フォーム入力値が `pdf.text` / `pdf.addImage` / `pdf.save` に直接混入していない

### フォローアップ Issue
- `next/font/local` 移行 + Noto Sans JP / Inter subset 化（仕様書 §4.1 正本）
- `DashboardView` 抽出リファクタ（`ResultDashboard` / `PdfDashboard` 共有）
- 連絡先（メールアドレス）正式値の確定（仕様書 §13.5）
- 正式ロゴ SVG 配置（仕様書 §6.4）
- カテゴリ訴求文言の確定（仕様書 §13.6）
- iPad / iOS Safari 実機検証（仕様書 §13.4）
- `pdf.html()` を呼ばない契約の CI 化（`eslint-plugin-no-restricted-syntax`）

### 手動検証推奨項目
- 4 種の入力パターン（警告発動 / 警告非発動 / 完全内製 / 桁爆発）で目視確認
- ファイル名のタイムゾーン固定（端末を US/Pacific に切り替えて JST 表記が維持されること）
- 連続生成時のメモリリーク（DevTools Memory タブで線形増加しないこと）
- iOS Safari でダウンロードが完了し 10 秒以内に収まること
