### PR TITLE
feat(meta): PWA Manifest 追加と OGP/Twitter image の不整合解消 (#44)

### DIFF
--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -226,3 +226,35 @@ export function cn(
 | `cn` を極小自前実装にする（`clsx` / `tailwind-merge` 不採用） | §8.3 |
 | `Input` / フォーム部品ラッパは本 Issue では作らない | §8.2.3 |
 | `Card` の variant / composition API は持たない | §8.2.2, §21 R15 |
+
+---
+
+## 12. PWA / メタデータ資産
+
+ブラウザタブ / SNS シェア / ホーム画面追加で表示される画像とメタ情報のソース・オブ・トゥルース。Issue #44 でファイルベース API + `manifest.ts` 方式に統一。
+
+### 12.1 画像資産（Next.js App Router ファイルベース API）
+
+| 資産 | 配置パス | サイズ | 用途 | 暫定/確定 |
+|---|---|---|---|---|
+| favicon | `src/app/favicon.ico` | 16x16 / 32x32 マルチサイズ | ブラウザタブ | 暫定（最終差し替えは別 Issue） |
+| icon (SVG) | `src/app/icon.svg` | 32x32 viewBox | モダンブラウザ | 暫定 |
+| apple-touch-icon | `src/app/apple-icon.png` | 180x180 | iOS ホーム画面 | 暫定 |
+| OG / Twitter card | `src/app/opengraph-image.png` | 1200x630 | SNS シェア時のプレビュー | 暫定 |
+
+差し替え時は `src/app/` 内のファイルを上書きするだけで HTML 側の `<link>` / `<meta>` が自動追従する（コード変更不要）。`public/` への重複配置は行わない。
+
+### 12.2 PWA Web App Manifest
+
+`src/app/manifest.ts` に集約。ビルド時に `out/manifest.webmanifest` として出力され、`<link rel="manifest" href="/manifest.webmanifest" />` で参照される。
+
+| プロパティ | 値 | 出典 |
+|---|---|---|
+| `name` / `short_name` | `SITE_NAME`（"またたび計算機"） | `src/app/layout.tsx` から re-export |
+| `description` | `SITE_DESCRIPTION` | `src/app/layout.tsx` から re-export |
+| `background_color` | `#F8F6F2` | §2 `canvas` / `offwhite` |
+| `theme_color` | `#F8F6F2` | `layout.tsx` の `viewport.themeColor` と一致 |
+| `display` | `standalone` | ホーム画面追加時にブラウザ Chrome を隠す |
+| `start_url` / `scope` | `/` | LP ルート |
+
+`background_color` / `theme_color` の HEX を変える際は §2 のカラーロールも合わせて更新する。

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,9 +23,9 @@ const notoSansJp = Noto_Sans_JP({
 
 const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://roi.nekonimatatabi.com";
-const SITE_NAME = "またたび計算機";
+export const SITE_NAME = "またたび計算機";
 const SITE_DEFAULT_TITLE = "またたび計算機 | IT コスト診断・ROI 試算ツール";
-const SITE_DESCRIPTION =
+export const SITE_DESCRIPTION =
   "中小企業の経営者向け ROI 診断ツール。月額ベンダー費用や改修費、手作業時間を 5 つの質問に答えるだけで、3 年間で止血できる IT コストと取り逃している利益を試算。結果は PDF で出力でき、登録不要・完全無料でご利用いただけます。";
 
 export const metadata: Metadata = {
@@ -40,6 +40,7 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "/",
   },
+  manifest: "/manifest.webmanifest",
   robots: {
     index: true,
     follow: true,
@@ -61,7 +62,6 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: SITE_DEFAULT_TITLE,
     description: SITE_DESCRIPTION,
-    images: ["/opengraph-image.png"],
   },
 };
 

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,39 @@
+import type { MetadataRoute } from "next";
+import { SITE_DESCRIPTION, SITE_NAME } from "./layout";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: SITE_NAME,
+    short_name: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    start_url: "/",
+    scope: "/",
+    display: "standalone",
+    orientation: "portrait",
+    lang: "ja",
+    // matches tailwind canvas / offwhite (#F8F6F2) and layout.tsx viewport.themeColor
+    background_color: "#F8F6F2",
+    theme_color: "#F8F6F2",
+    icons: [
+      {
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+      {
+        src: "/apple-icon.png",
+        sizes: "180x180",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/favicon.ico",
+        sizes: "16x16 32x32",
+        type: "image/x-icon",
+        purpose: "any",
+      },
+    ],
+    categories: ["business", "productivity", "finance"],
+  };
+}


### PR DESCRIPTION
## 概要
- Issue #44 で要望された OGP / favicon / apple-touch-icon のメタ整備のうち、未対応の **PWA Web App Manifest 追加** を実施。
- 既存のファイルベース API (`src/app/{favicon.ico, icon.svg, apple-icon.png, opengraph-image.png}`) はそのまま活かし、`src/app/manifest.ts` を新規追加して `out/manifest.webmanifest` を生成。
- 副次的に `og:image` / `twitter:image` のハッシュ不整合（`twitter.images` 手書きによる二重指定）を解消。

## 詳細

### 変更内容
1. **新規**: `src/app/manifest.ts`
   - `MetadataRoute.Manifest` 形式で `name` / `short_name` / `description` / `start_url` / `scope` / `display: standalone` / `orientation: portrait` / `lang: ja` / `background_color: #F8F6F2` / `theme_color: #F8F6F2` / `icons` (3 件) / `categories` を定義。
   - `SITE_NAME` / `SITE_DESCRIPTION` は `layout.tsx` から再利用（コピーライティングの単一ソース化）。
2. **変更**: `src/app/layout.tsx`
   - `metadata.manifest: "/manifest.webmanifest"` を追加。
   - `twitter.images: ["/opengraph-image.png"]` を削除（ファイルベース API に委譲し、`og:image` と同じハッシュ付き URL を自動生成させる）。
   - `SITE_NAME` / `SITE_DESCRIPTION` を `export` 化（`manifest.ts` から import するため）。
3. **変更**: `docs/design-tokens.md`
   - 末尾に「12. PWA / メタデータ資産」セクションを追加し、icon / OGP 画像の所在と `theme_color` / `background_color` の出典を明記。

### 設計判断
- App Router ファイルベース API + `manifest.ts`（メタデータルート）方式に統一。`public/manifest.json` ではなく TS 形式を採用したのは `SITE_NAME` / `SITE_DESCRIPTION` を `layout.tsx` と単一ソースで保つため。
- `metadata.icons` は **手書きしない**。ファイルベース API による自動検出を活かす（ファイル差し替えだけで HTML が追従する利点を取る）。
- 画像バイナリは既存の暫定資産を継続利用。最終差し替えは別 Issue（#9 ブランド資産タスク等）でデザイン担当者が対応する前提。

### 検証結果
- `npm run typecheck` ✓
- `npm run lint` ✓ (No ESLint warnings or errors)
- `npm run build` ✓ (`/manifest.webmanifest` が `out/` 配下に生成、JSON valid 確認済み)
- `out/index.html` の確認:
  - `<link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials"/>` 出力済み
  - `og:image` と `twitter:image` が同一ハッシュ付き URL `opengraph-image.png?daedb8584fcafd22` を指す（不整合解消）
  - `<link rel="icon">` (favicon.ico / icon.svg) と `<link rel="apple-touch-icon">` がファイルベース API から自動生成

## 参考
Closes #44

関連: プランファイル `working/plans/issue-44-ogp-favicon-apple-touch-icon-meta-setup_260502122638.md`

## 注意事項
- 受け入れ条件「Lighthouse PWA 監査で `Web app manifest meets the installability requirements` がパスすること」については、192/512 PNG が無い暫定状態のため一部警告が出る可能性あり。192/512 アイコンの追加は別 Issue でフォロー予定。
- 受け入れ条件「`metadata.icons` が更新済み」については、ファイルベース API 採用時には手書き不要との設計判断で `metadata.icons` は明示記述していません（プラン §A 参照）。
- 本番環境での Twitter Card Validator / Facebook Sharing Debugger によるプレビュー確認は、マージ後の本番反映タイミングで実施してください。
