### PR TITLE
refactor(hooks): useSyncExternalStore で react-hooks 抑制負債を返済 (#66)

### DIFF
--- a/src/components/calculate/ResultDashboard.tsx
+++ b/src/components/calculate/ResultDashboard.tsx
@@ -48,6 +48,7 @@ import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { cn } from "@/lib/cn";
 import { useCountUp } from "@/hooks/useCountUp";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { formatManYen, formatManYenCompact, formatPercent } from "@/lib/format";
 import type { InsourcingLevel } from "@/lib/constants";
 import type { CalculationInput, CalculationOutput } from "@/lib/calculation";
@@ -65,36 +66,6 @@ const MOBILE_QUERY = "(max-width: 639px)";
 const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 const SAVINGS_LABEL = "3 年間の止血";
 const PROFIT_LABEL = "3 年間の利益創出";
-
-function useReducedMotion(): boolean {
-  const [reduced, setReduced] = useState<boolean>(false);
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mql = window.matchMedia(REDUCED_MOTION_QUERY);
-    // SSR ハイドレーション後に matchMedia の実値で初期同期するための setState。
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setReduced(mql.matches);
-    const onChange = (event: MediaQueryListEvent) => setReduced(event.matches);
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
-  return reduced;
-}
-
-function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState<boolean>(false);
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mql = window.matchMedia(MOBILE_QUERY);
-    // SSR ハイドレーション後に matchMedia の実値で初期同期するための setState。
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setIsMobile(mql.matches);
-    const onChange = (event: MediaQueryListEvent) => setIsMobile(event.matches);
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
-  return isMobile;
-}
 
 export type ResultDashboardProps = {
   /** calculate() の戻り値（円単位の浮動小数）。 */
@@ -129,13 +100,13 @@ export function ResultDashboard({
   onResetRequest,
   className,
 }: ResultDashboardProps) {
-  const reducedMotion = useReducedMotion();
-  const isMobile = useIsMobile();
+  const reducedMotion = useMediaQuery(REDUCED_MOTION_QUERY);
+  const isMobile = useMediaQuery(MOBILE_QUERY);
 
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
   const [pdfError, setPdfError] = useState<string | null>(null);
+  const [generatedAt, setGeneratedAt] = useState<Date | null>(null);
   const pdfDashboardRef = useRef<HTMLDivElement | null>(null);
-  const generatedAtRef = useRef<Date | null>(null);
   // 早期 return 用に最新フラグを ref で保持し、`useCallback` の deps を空にして
   // ハンドラ参照を安定させる（`<Button onClick>` の不要な props 変化を抑制）。
   const isGeneratingPdfRef = useRef(false);
@@ -151,8 +122,8 @@ export function ResultDashboard({
     if (isGeneratingPdfRef.current) return;
     isGeneratingPdfRef.current = true;
     setPdfError(null);
-    const generatedAt = new Date();
-    generatedAtRef.current = generatedAt;
+    const now = new Date();
+    setGeneratedAt(now);
     setIsGeneratingPdf(true);
     try {
       // 仕様書 §8.1: requestAnimationFrame 2 回分待機（DOM レイアウト確定 + フォント解決）。
@@ -167,7 +138,7 @@ export function ResultDashboard({
       }
       await generatePdf({
         element,
-        filename: buildPdfFilename(generatedAt),
+        filename: buildPdfFilename(now),
       });
     } catch (err) {
       // 仕様書 §8.3: コンソールに詳細を出力しつつ、UI には固定文言を表示。
@@ -177,7 +148,7 @@ export function ResultDashboard({
       );
     } finally {
       setIsGeneratingPdf(false);
-      generatedAtRef.current = null;
+      setGeneratedAt(null);
       isGeneratingPdfRef.current = false;
     }
   }, []);
@@ -411,9 +382,7 @@ export function ResultDashboard({
             result={result}
             insourcingLevel={insourcingLevel}
             inputs={inputs}
-            // PDF 生成開始時にハンドラ側で current にセット済み。レンダー時は読み出すだけ。
-            // eslint-disable-next-line react-hooks/refs
-            generatedAt={generatedAtRef.current ?? new Date()}
+            generatedAt={generatedAt ?? new Date()}
           />
         </div>
       ) : null}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useCountUp, easeOutCubic } from "./useCountUp";
 export type { UseCountUpOptions } from "./useCountUp";
+export { useMediaQuery } from "./useMediaQuery";

--- a/src/hooks/useCountUp.ts
+++ b/src/hooks/useCountUp.ts
@@ -11,6 +11,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
+import { useMediaQuery } from "./useMediaQuery";
 
 /** カウンターの標準 duration（ミリ秒）。docs/spec/result-dashboard.md §6.1 で確定。 */
 const DEFAULT_DURATION_MS = 1_200;
@@ -57,27 +58,12 @@ export function useCountUp(
 
   // 初期値 0 はマウント時の 0 → target 立ち上げアニメ（仕様書 §6.4）を実現するための固定値。
   const [value, setValue] = useState<number>(0);
-  const [reducedMotion, setReducedMotion] = useState<boolean>(false);
+  const reducedMotion = useMediaQuery(REDUCED_MOTION_QUERY);
 
   const rafIdRef = useRef<number | null>(null);
   const startTimeRef = useRef<number | null>(null);
   const startValueRef = useRef<number>(0);
   const valueRef = useRef<number>(0);
-
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mql = window.matchMedia(REDUCED_MOTION_QUERY);
-    // SSR ハイドレーション後に matchMedia の実値で初期同期するための setState。
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setReducedMotion(mql.matches);
-    const onChange = (event: MediaQueryListEvent) => {
-      setReducedMotion(event.matches);
-    };
-    mql.addEventListener("change", onChange);
-    return () => {
-      mql.removeEventListener("change", onChange);
-    };
-  }, []);
 
   useEffect(() => {
     // target が NaN / Infinity の場合は rAF を起動せず現在値を保持する。

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,43 @@
+"use client";
+
+/**
+ * メディアクエリの match 状態を返すフック（`useSyncExternalStore` ベース）。
+ *
+ * - 仕様: docs/spec/result-dashboard.md §6.3（prefers-reduced-motion 尊重）/
+ *         §7（レスポンシブ・mobile breakpoint）
+ * - 設計: React 19 公式の外部ストア購読 API `useSyncExternalStore` を用い、
+ *         SSR 時は `getServerSnapshot` で `false` を返してハイドレーション後に
+ *         `window.matchMedia` の実値で同期する。
+ *         `subscribe` は query をクロージャに閉じ込める必要があり、
+ *         参照安定化のため `useCallback` で `[query]` 依存メモ化する。
+ * - 依存: react（useSyncExternalStore / useCallback）。
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+export function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      if (typeof window === "undefined" || !window.matchMedia) {
+        return () => {};
+      }
+      const mql = window.matchMedia(query);
+      mql.addEventListener("change", callback);
+      return () => mql.removeEventListener("change", callback);
+    },
+    [query],
+  );
+
+  const getSnapshot = useCallback((): boolean => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return false;
+    }
+    return window.matchMedia(query).matches;
+  }, [query]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## 概要
PR #65 (Next.js 16 メジャー更新) で局所抑制した React 19 / Next.js 16 由来の新 ESLint ルール `react-hooks/set-state-in-effect` および `react-hooks/refs` の `eslint-disable-next-line` 計 4 箇所を、React 19 公式パターンの `useSyncExternalStore` ベースのリファクタによって返済します。

## 詳細
### 変更内容
- **新規**: `src/hooks/useMediaQuery.ts` を `useSyncExternalStore` ベースで実装。SSR フォールバックは `false`、クライアント時は `window.matchMedia(query).matches` を返却。
- `src/hooks/index.ts`: `useMediaQuery` を re-export に追加。
- `src/components/calculate/ResultDashboard.tsx`:
  - ローカル定義の `useReducedMotion` / `useIsMobile` (29 行) を削除し、`useMediaQuery(REDUCED_MOTION_QUERY)` / `useMediaQuery(MOBILE_QUERY)` の呼び出しに置換。これにより `react-hooks/set-state-in-effect` の `eslint-disable-next-line` 2 件が自動削除。
  - `generatedAtRef` (`useRef<Date | null>`) を `useState<Date | null>` の `generatedAt` に置換。`handleDownloadPdf` 内では `setGeneratedAt(now)` → `setIsGeneratingPdf(true)` を連続呼び出しすることで React 19 の自動バッチで 1 レンダーに統合され、`<PdfDashboard />` の初回マウント時に最新値が確実に渡る。これにより `react-hooks/refs` の `eslint-disable-next-line` 1 件が削除。
- `src/hooks/useCountUp.ts`:
  - `reducedMotion` の `useState` + `useEffect` (matchMedia 購読) 構成を `useMediaQuery(REDUCED_MOTION_QUERY)` 呼び出しに置換。これにより `react-hooks/set-state-in-effect` の `eslint-disable-next-line` 1 件が自動削除。

### 受け入れ条件
- [x] `react-hooks/set-state-in-effect` / `react-hooks/refs` の `eslint-disable-next-line` がプロジェクト全体で 0 件 (`grep -rn "eslint-disable-next-line react-hooks" src/` で確認済み)
- [x] `useMediaQuery` フックを `src/hooks/useMediaQuery.ts` として共通化（重複コード削減）
- [x] `npm run lint` / `npm run typecheck` / `npm run build` が exit 0
- [x] `PdfDashboard` の `generatedAt: Date` props 型契約は無変更（仕様書 `docs/spec/pdf-report.md §11.1` 維持）

### マージャー手動確認事項 (実機確認)
レビュー後マージ前に以下の手動確認をお願いします（仕様書準拠の挙動保証のため）。
- [ ] **reduced-motion**: macOS「視差効果を減らす」ON または DevTools 「Emulate CSS media feature prefers-reduced-motion: reduce」有効化 → `/calculate` で診断 → カウンターが即時最終値表示・Recharts のバーアニメも無効になることを確認 (仕様 `result-dashboard.md §6.3`)
- [ ] **mobile breakpoint**: DevTools レスポンシブ幅 < 640px → `chartHeight` が `BAR_HEIGHT_MOBILE` (100px) に切り替わることを確認 (仕様 `result-dashboard.md §7`)
- [ ] **PDF 生成**: 「PDF をダウンロード」→ 表紙の生成日時が JST で正しく刻印・ファイル名が `matatabi-roi-YYYYMMDD-HHmm.pdf` であることを確認 (仕様 `pdf-report.md §11.4`)
- [ ] **再診断フロー**: PDF ダウンロード後に「再診断する」→ フォーム再表示 → 再度診断 → 再度 PDF ダウンロードが連続で動作することを確認 (`generatedAt` state の reset サイクル)

## 参考
Closes #66

関連: PR #65 (Next.js 16 メジャー更新で発生した抑制負債)

## 注意事項
- `MOBILE_QUERY` / `REDUCED_MOTION_QUERY` 定数は ResultDashboard / useCountUp の双方で同一文字列を保持しており、本 Issue ではスコープ外として現状維持（共通化は別 Issue）。
- `useMediaQuery` のテストファイルは現状追加なし（既存 `useCountUp` にもテストなしのため、本リファクタはスコープ外）。実機確認で挙動保証する受け入れ条件と整合。
- React 19 自動バッチ前提のため、レンダーフローに依存する場合は `setGeneratedAt` → `setIsGeneratingPdf` の順序を変更しないこと。
