### PR TITLE
refactor(media-query): メディアクエリ定数を共通化し generatedAt フォールバックを撤去 (#71)

### DIFF
--- a/src/components/calculate/ResultDashboard.tsx
+++ b/src/components/calculate/ResultDashboard.tsx
@@ -49,6 +49,7 @@ import { Card } from "@/components/ui/Card";
 import { cn } from "@/lib/cn";
 import { useCountUp } from "@/hooks/useCountUp";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { MOBILE_QUERY, REDUCED_MOTION_QUERY } from "@/lib/mediaQueries";
 import { formatManYen, formatManYenCompact, formatPercent } from "@/lib/format";
 import type { InsourcingLevel } from "@/lib/constants";
 import type { CalculationInput, CalculationOutput } from "@/lib/calculation";
@@ -62,8 +63,6 @@ const TOOLTIP_CURSOR_FILL = "rgba(156, 174, 184, 0.08)";
 const BAR_HEIGHT_DESKTOP = 120;
 const BAR_HEIGHT_MOBILE = 100;
 const RECHARTS_ANIM_MS = 800;
-const MOBILE_QUERY = "(max-width: 639px)";
-const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 const SAVINGS_LABEL = "3 年間の止血";
 const PROFIT_LABEL = "3 年間の利益創出";
 
@@ -367,7 +366,7 @@ export function ResultDashboard({
         ) : null}
       </div>
 
-      {isGeneratingPdf ? (
+      {isGeneratingPdf && generatedAt ? (
         <div
           aria-hidden="true"
           style={{
@@ -382,7 +381,7 @@ export function ResultDashboard({
             result={result}
             insourcingLevel={insourcingLevel}
             inputs={inputs}
-            generatedAt={generatedAt ?? new Date()}
+            generatedAt={generatedAt}
           />
         </div>
       ) : null}

--- a/src/hooks/useCountUp.ts
+++ b/src/hooks/useCountUp.ts
@@ -12,15 +12,13 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useMediaQuery } from "./useMediaQuery";
+import { REDUCED_MOTION_QUERY } from "@/lib/mediaQueries";
 
 /** カウンターの標準 duration（ミリ秒）。docs/spec/result-dashboard.md §6.1 で確定。 */
 const DEFAULT_DURATION_MS = 1_200;
 
 /** ease-out cubic。t ∈ [0, 1] を [0, 1] に写像する。 */
 export const easeOutCubic = (t: number): number => 1 - (1 - t) ** 3;
-
-/** prefers-reduced-motion: reduce のメディアクエリ文字列。 */
-const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 
 export type UseCountUpOptions = {
   /** アニメーション持続時間（ミリ秒）。既定 1,200ms。 */

--- a/src/lib/mediaQueries.ts
+++ b/src/lib/mediaQueries.ts
@@ -1,0 +1,16 @@
+/**
+ * メディアクエリ文字列定数の集約。
+ *
+ * - 仕様: docs/spec/result-dashboard.md §6.3（prefers-reduced-motion 尊重）/
+ *         §7（mobile breakpoint）
+ * - 設計: `useMediaQuery`（`useSyncExternalStore` ベース）に渡すクエリ文字列の
+ *         単一の真実の源。`ResultDashboard` と `useCountUp` で同一文字列を別々に
+ *         保持していた重複を解消する。`tailwind.config.ts` の `sm` ブレークポイント
+ *         （640px）と整合する `(max-width: 639px)` を使用。
+ */
+
+/** モバイル判定（sm ブレークポイント未満）に使うメディアクエリ文字列。 */
+export const MOBILE_QUERY = "(max-width: 639px)";
+
+/** prefers-reduced-motion: reduce のメディアクエリ文字列。 */
+export const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";


### PR DESCRIPTION
## 概要
PR #70（Issue #66）で導入した `useSyncExternalStore` ベースの `useMediaQuery` 共通フックの後片付け。`MOBILE_QUERY` / `REDUCED_MOTION_QUERY` の同一文字列が 2 ファイルで重複定義されていたのを `src/lib/mediaQueries.ts` 新規追加で集約し、`<PdfDashboard generatedAt={generatedAt ?? new Date()} />` のフォールバック描画を AND 条件描画に置き換えて PDF 表紙とファイル名のタイムスタンプ齟齬の潜在リスクを解消する。

## 詳細

### 変更内容
- **新規**: `src/lib/mediaQueries.ts` を追加し `MOBILE_QUERY = "(max-width: 639px)"` / `REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)"` を集約。既存 lib ファイル（`pdfConstants.ts` / `constants.ts`）と整合する日本語 JSDoc ヘッダーを付与。
- **変更**: `src/components/calculate/ResultDashboard.tsx`
  - 65-66 行のローカル定義を削除し、`@/lib/mediaQueries` から import に切り替え。
  - 隠しマウント JSX を `isGeneratingPdf` 単独条件から `isGeneratingPdf && generatedAt` AND 条件に変更し、`generatedAt ?? new Date()` フォールバックを撤去。
- **変更**: `src/hooks/useCountUp.ts`
  - 23 行の `REDUCED_MOTION_QUERY` ローカル定義（および直前の JSDoc コメント）を削除し、`@/lib/mediaQueries` から import に切り替え。`useMediaQuery` は引き続き相対 import（既存秩序維持）。

### 設計上の根拠
- 文字列リテラルは完全一致のためランタイム挙動は等価。`useMediaQuery` の `useCallback([query])` 依存も同値で再購読は発生しない。
- `handleDownloadPdf` 内で `setGeneratedAt(now)` → `setIsGeneratingPdf(true)` は React 19 の自動バッチで 1 レンダーに統合されるため、`isGeneratingPdf === true && generatedAt === null` の中間状態は通常到達しない。AND 条件にしておくことで、将来の React アップグレードや Suspense / Concurrent 周りの非互換が入ったときの PDF 表紙 vs ファイル名タイムスタンプ齟齬を防御的に回避。

### 検証
- `npm run lint` ✅ exit 0
- `npm run typecheck` ✅ exit 0
- `npm run build` ✅ exit 0（13/13 静的ページ生成成功）

## 参考
- Closes #71
- 前段 PR: #70（Issue #66 — useSyncExternalStore リファクタ）
- 仕様: `docs/spec/result-dashboard.md §6.3` (prefers-reduced-motion 尊重) / §7 (mobile breakpoint)

## 注意事項
- 実機ブラウザでの最終確認（PDF ダウンロード時の表紙日時/ファイル名一致、`prefers-reduced-motion` 有効時の即時表示、`max-width: 639px` でのチャート高さ切り替え）はマージ前にレビュアー側で確認をお願いします。
- ワーキングツリーには本 PR と無関係な `.claude/skills/...` 関連の変更が複数残っていますが、本コミットには含まれていません（`git add` で対象 3 ファイルのみを明示的にステージング済み）。
