### PR TITLE
refactor(result-dashboard): DashboardView を抽出し §10.2 3 層分離を本実装化 (#73)

### DIFF
--- a/src/components/calculate/DashboardView.tsx
+++ b/src/components/calculate/DashboardView.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+/**
+ * ROI 診断結果ダッシュボードの描画層（仕様書 docs/spec/result-dashboard.md §10.2）。
+ *
+ * - 仕様: docs/spec/result-dashboard.md §3〜§9（ヒーロー / 補助カード / 積み上げ横棒 /
+ *         §6 アニメーション方針 / §9 表示単位）／docs/design-tokens.md §2〜§5
+ * - 設計: 副作用ゼロの pure component。`useState` / `useEffect` / `useRef` /
+ *         カスタムフック（`useCountUp` / `useMediaQuery` 等）は一切使用しない。
+ *         `useCountUp` × 4 の補間値（`animatedSavings` / `animatedAnnualProfit` /
+ *         `animatedThreeYearProfit` / `animatedTotal`）はコンテナ（`ResultDashboard`）が
+ *         実行し、props として注入する。`isMobile` / `animated` も同様にコンテナ側で
+ *         `useMediaQuery` から導出した値を props 経由で受け取る。
+ *         `useMemo` のみ描画派生値の最適化用に許容（副作用ではないため pure 基準に抵触しない）。
+ *         Recharts は SSR 段階で `ResizeObserver` 等のブラウザ API に依存するため、
+ *         本ファイルも `"use client"` を宣言し、最終的な遅延ロード境界（`next/dynamic({ ssr: false })`）
+ *         はさらに上流（CalculatePageClient）に置く。
+ * - トークン追従: `ACCENT_HEX` / `ACCENT_60` / `TOOLTIP_CURSOR_FILL` は
+ *         `tailwind.config.ts` の `accent` (#9CAEB8) と同値の手書き定数。
+ *         `docs/design-tokens.md §2` の「CSS 変数を挟まない」方針に沿った意図的設計のため、
+ *         `accent` を変更する際は本ファイルも併せて更新すること。
+ * - 凡例の表示値: `<Legend>` 内では `result.threeYearSavings` 等の最終値を静的表示する。
+ *         グラフアニメーション 800ms 中はバー長と凡例数値が一瞬不整合になるが、
+ *         凡例は「最終的に到達する値」を示すラベルとして役割が明確なため意図的に静的化。
+ * - 依存: recharts（v2 系）／lucide-react／@/components/ui/Button／@/components/ui/Card／
+ *         @/lib/cn／@/lib/format／@/lib/calculation／@/lib/constants
+ */
+
+import { useMemo, type ReactNode } from "react";
+import {
+  Bar,
+  BarChart,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Loader2, PiggyBank, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { cn } from "@/lib/cn";
+import { formatManYen, formatManYenCompact, formatPercent } from "@/lib/format";
+import type { InsourcingLevel } from "@/lib/constants";
+import type { CalculationOutput } from "@/lib/calculation";
+
+const ACCENT_HEX = "#9CAEB8";
+const ACCENT_60 = "rgba(156, 174, 184, 0.6)";
+const TOOLTIP_CURSOR_FILL = "rgba(156, 174, 184, 0.08)";
+const BAR_HEIGHT_DESKTOP = 120;
+const BAR_HEIGHT_MOBILE = 100;
+const RECHARTS_ANIM_MS = 800;
+const SAVINGS_LABEL = "3 年間の止血";
+const PROFIT_LABEL = "3 年間の利益創出";
+
+export interface DashboardViewProps {
+  result: CalculationOutput;
+  insourcingLevel: InsourcingLevel;
+  animated: boolean;
+  animatedSavings: number;
+  animatedAnnualProfit: number;
+  animatedThreeYearProfit: number;
+  animatedTotal: number;
+  isMobile: boolean;
+  onDownloadPdf: () => void;
+  onResetRequest?: () => void;
+  isGeneratingPdf: boolean;
+  pdfError: string | null;
+  headerSlot?: ReactNode;
+  className?: string;
+}
+
+export function DashboardView({
+  result,
+  insourcingLevel,
+  animated,
+  animatedSavings,
+  animatedAnnualProfit,
+  animatedThreeYearProfit,
+  animatedTotal,
+  isMobile,
+  onDownloadPdf,
+  onResetRequest,
+  isGeneratingPdf,
+  pdfError,
+  headerSlot,
+  className,
+}: DashboardViewProps) {
+  const insourcingPercent = formatPercent(insourcingLevel);
+  const isFullyInsourced = insourcingLevel === 1;
+  const isPartiallyInsourced = insourcingLevel > 0 && insourcingLevel < 1;
+  const chartHeight = isMobile ? BAR_HEIGHT_MOBILE : BAR_HEIGHT_DESKTOP;
+
+  const chartData = useMemo(
+    () => [
+      {
+        label: "3年合計",
+        savings: result.threeYearSavings,
+        profit: result.threeYearProfitCreation,
+      },
+    ],
+    [result.threeYearSavings, result.threeYearProfitCreation],
+  );
+
+  return (
+    <section
+      role="region"
+      aria-label="ROI 診断結果"
+      className={cn(
+        "mx-auto w-full max-w-[1024px] space-y-4 sm:space-y-6",
+        className,
+      )}
+    >
+      {headerSlot ? <div>{headerSlot}</div> : null}
+
+      <Card className="py-8 text-center sm:py-12">
+        <p className="text-sm font-medium text-ink/80">
+          3 年間のトータルインパクト
+        </p>
+        <p
+          aria-live="polite"
+          aria-atomic="true"
+          className="mt-3 text-[clamp(2.5rem,6vw,4rem)] font-bold leading-tight text-ink"
+        >
+          {formatManYenCompact(animatedTotal)}
+        </p>
+        <p className="mt-2 text-xs text-ink/60">※ 試算上の最大値</p>
+      </Card>
+
+      <div className="grid grid-cols-1 gap-4 sm:mx-auto sm:max-w-[720px] sm:grid-cols-2 sm:gap-6">
+        <Card>
+          <div className="flex items-center gap-2 text-ink">
+            <PiggyBank aria-hidden="true" className="h-5 w-5 text-accent" />
+            <h3 className="text-sm font-medium">3 年間の止血</h3>
+          </div>
+          <p
+            aria-live="polite"
+            aria-atomic="true"
+            className="mt-3 text-3xl font-bold text-ink"
+          >
+            {formatManYen(animatedSavings)}
+          </p>
+          {isFullyInsourced ? (
+            <p className="mt-2 text-xs text-ink/70">
+              現状、理想形に近い運用のため削減余地は 0 万円
+            </p>
+          ) : isPartiallyInsourced ? (
+            <p className="mt-2 text-xs text-ink/70">
+              既に内製化されている <strong>{insourcingPercent}</strong>{" "}
+              相当分は削減余地から除外済み
+            </p>
+          ) : null}
+        </Card>
+
+        <Card>
+          <div className="flex items-center gap-2 text-ink">
+            <Sparkles aria-hidden="true" className="h-5 w-5 text-accent" />
+            <h3 className="text-sm font-medium">年間の利益創出</h3>
+          </div>
+          <p
+            aria-live="polite"
+            aria-atomic="true"
+            className="mt-3 text-3xl font-bold text-ink"
+          >
+            {formatManYen(animatedAnnualProfit)}
+          </p>
+          <p className="mt-2 text-xs text-ink/70">
+            × 3 年 = {formatManYen(animatedThreeYearProfit)}
+          </p>
+        </Card>
+      </div>
+
+      <Card className="mx-auto w-full max-w-[960px]">
+        <figure className="space-y-3">
+          <figcaption className="sr-only">
+            3 年間の止血と 3 年間の利益創出を積み上げた横棒グラフ。合計が
+            {formatManYen(result.totalThreeYearImpact)}。
+          </figcaption>
+          <ResponsiveContainer width="100%" height={chartHeight}>
+            <BarChart
+              data={chartData}
+              layout="vertical"
+              margin={{ top: 8, right: 24, bottom: 8, left: 16 }}
+            >
+              <XAxis
+                type="number"
+                tickFormatter={(value: number) => formatManYen(value)}
+                stroke={ACCENT_HEX}
+              />
+              <YAxis type="category" dataKey="label" hide />
+              <Tooltip
+                formatter={(value: number) => formatManYen(value)}
+                cursor={{ fill: TOOLTIP_CURSOR_FILL }}
+              />
+              <Legend
+                verticalAlign="bottom"
+                content={() => (
+                  <ul className="flex flex-wrap justify-center gap-x-6 gap-y-2 pt-2 text-xs text-ink">
+                    <li className="flex items-center gap-2">
+                      <PiggyBank
+                        aria-hidden="true"
+                        className="h-4 w-4 text-accent"
+                      />
+                      <span>{SAVINGS_LABEL}</span>
+                      <span className="font-semibold">
+                        {formatManYen(result.threeYearSavings)}
+                      </span>
+                    </li>
+                    <li className="flex items-center gap-2">
+                      <Sparkles
+                        aria-hidden="true"
+                        className="h-4 w-4 text-accent/60"
+                      />
+                      <span>{PROFIT_LABEL}</span>
+                      <span className="font-semibold">
+                        {formatManYen(result.threeYearProfitCreation)}
+                      </span>
+                    </li>
+                  </ul>
+                )}
+              />
+              <Bar
+                dataKey="savings"
+                name={SAVINGS_LABEL}
+                stackId="impact"
+                fill={ACCENT_HEX}
+                radius={[2, 0, 0, 2]}
+                isAnimationActive={animated}
+                animationDuration={RECHARTS_ANIM_MS}
+              />
+              <Bar
+                dataKey="profit"
+                name={PROFIT_LABEL}
+                stackId="impact"
+                fill={ACCENT_60}
+                radius={[0, 2, 2, 0]}
+                isAnimationActive={animated}
+                animationDuration={RECHARTS_ANIM_MS}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </figure>
+
+        {isFullyInsourced ? (
+          <p className="mt-3 text-xs text-ink/70">
+            3 年間の利益創出のみで{" "}
+            {formatManYen(result.threeYearProfitCreation)}{" "}
+            のインパクトが見込めます。
+          </p>
+        ) : null}
+        {result.speedWarning && !headerSlot ? (
+          <p className="mt-3 text-xs text-ink/60">
+            更新待ち期間が 3 ヶ月以上のため、機会損失が継続中の可能性があります。
+          </p>
+        ) : null}
+      </Card>
+
+      <div className="flex flex-col items-center gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <Button
+            variant="primary"
+            size="lg"
+            type="button"
+            onClick={onDownloadPdf}
+            disabled={isGeneratingPdf}
+            aria-busy={isGeneratingPdf}
+          >
+            {isGeneratingPdf ? (
+              <>
+                <Loader2
+                  aria-hidden="true"
+                  className="h-4 w-4 animate-spin"
+                />
+                <span>PDF生成中…</span>
+              </>
+            ) : (
+              <span>PDF をダウンロード</span>
+            )}
+          </Button>
+          {onResetRequest ? (
+            <Button
+              variant="secondary"
+              size="lg"
+              type="button"
+              onClick={onResetRequest}
+            >
+              再診断する
+            </Button>
+          ) : null}
+        </div>
+        {pdfError ? (
+          <p role="alert" className="text-sm text-[#B45656]">
+            {pdfError}
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/calculate/ResultDashboard.tsx
+++ b/src/components/calculate/ResultDashboard.tsx
@@ -1,70 +1,46 @@
 "use client";
 
 /**
- * ROI 診断結果ダッシュボード。
+ * ROI 診断結果ダッシュボードの画面コンテナ（仕様書 docs/spec/result-dashboard.md §10.2）。
  *
- * - 仕様: docs/spec/result-dashboard.md §3〜§9（ヒーロー / 補助カード / 積み上げ横棒 /
- *         §6 アニメーション方針 / §9 表示単位）／docs/design-tokens.md §2〜§5
- *         docs/spec/pdf-report.md §8（生成フロー）/ §11.4（コンテナ責務）
+ * - 仕様: docs/spec/result-dashboard.md §10.2（3 層分離）／§6（アニメーション方針）／
+ *         docs/spec/pdf-report.md §8（PDF 生成フロー）／§11.4（コンテナ責務）
  * - 設計: 仕様書 §10.2 の「描画層 (`DashboardView`) / 画面コンテナ (`ResultDashboard`) /
- *         PDF 用ラッパ (`PdfDashboard`)」3 層分離は本実装では本ファイル 1 つに同居させた
- *         暫定構造で運用する。`DashboardView` 抽出は別 Issue として申し送り、
- *         本 Issue（#43）では `PdfDashboard` を独立コンポーネントとして並置する。
- *         Recharts は SSR 段階で `ResizeObserver` 等のブラウザ API に依存するため、
- *         呼び出し側（CalculatePageClient）で `next/dynamic({ ssr: false })` を経由する。
- *         PDF 生成中のみ `PdfDashboard` を `position: absolute; left: -9999px` で
- *         隠しマウントし、`forwardRef` 経由で取得した DOM ノードを `generatePdf()` に渡す。
- * - 依存: recharts（v2 系）／lucide-react／@/hooks/useCountUp／@/lib/format／
- *         @/lib/calculation／@/lib/constants／@/components/ui/Card／@/lib/cn／
- *         @/lib/pdf（dynamic import 内蔵）／@/lib/pdfFilename／./PdfDashboard
- * - トークン追従: `ACCENT_HEX` / `ACCENT_60` / `TOOLTIP_CURSOR_FILL` は
- *         `tailwind.config.ts` の `accent` (#9CAEB8) と同値の手書き定数。
- *         `docs/design-tokens.md §2` の「CSS 変数を挟まない」方針に沿った意図的設計のため、
- *         `accent` を変更する際は本ファイルも併せて更新すること。
- * - 凡例の表示値: `<Legend>` 内では `result.threeYearSavings` 等の最終値を静的表示する。
- *         グラフアニメーション 800ms 中はバー長と凡例数値が一瞬不整合になるが、
- *         凡例は「最終的に到達する値」を示すラベルとして役割が明確なため意図的に静的化。
+ *         PDF 用ラッパ (`PdfDashboard`)」3 層分離を本実装で踏襲する。
+ *         コンテナ責務に純化し、副作用と非描画関心のみを保持する:
+ *         - `useCountUp` × 4 を実行し補間値を `DashboardView` に props 注入する
+ *           （描画層を pure に保ち、PDF 等で `animated={false}` 強制を別経路で容易に再利用可能にする）。
+ *         - `useMediaQuery(REDUCED_MOTION_QUERY)` で OS 設定を読み取り、`animated={!reducedMotion}`
+ *           を boolean 化して下流に渡す境界を本コンテナに集約する。
+ *         - `useMediaQuery(MOBILE_QUERY)` で `isMobile` を導出し、`DashboardView` の
+ *           `chartHeight` 切替に注入する（`DashboardView` を hook フリーに保つため）。
+ *         - PDF 生成中のみ `PdfDashboard` を `position: absolute; left: -9999px` で
+ *           隠しマウントし、`forwardRef` 経由で取得した DOM ノードを `generatePdf()` に渡す。
+ *           `pdfDashboardRef` / `generatedAt` state / `inputs` props を伴うため、
+ *           隠しマウント JSX は `DashboardView` には移さず本コンテナに残置する。
+ *         - Recharts は SSR 段階で `ResizeObserver` 等のブラウザ API に依存するため、
+ *           呼び出し側（CalculatePageClient）で `next/dynamic({ ssr: false })` を経由する。
+ * - 依存: @/hooks/useCountUp／@/hooks/useMediaQuery／@/lib/mediaQueries／
+ *         @/lib/calculation／@/lib/constants／@/lib/pdf（dynamic import 内蔵）／
+ *         @/lib/pdfFilename／./DashboardView／./PdfDashboard
  */
 
 import {
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
   type ReactNode,
 } from "react";
-import {
-  Bar,
-  BarChart,
-  Legend,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
-import { Loader2, PiggyBank, Sparkles } from "lucide-react";
-import { Button } from "@/components/ui/Button";
-import { Card } from "@/components/ui/Card";
-import { cn } from "@/lib/cn";
 import { useCountUp } from "@/hooks/useCountUp";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { MOBILE_QUERY, REDUCED_MOTION_QUERY } from "@/lib/mediaQueries";
-import { formatManYen, formatManYenCompact, formatPercent } from "@/lib/format";
 import type { InsourcingLevel } from "@/lib/constants";
 import type { CalculationInput, CalculationOutput } from "@/lib/calculation";
 import { generatePdf } from "@/lib/pdf";
 import { buildPdfFilename } from "@/lib/pdfFilename";
+import { DashboardView } from "./DashboardView";
 import { PdfDashboard } from "./PdfDashboard";
-
-const ACCENT_HEX = "#9CAEB8";
-const ACCENT_60 = "rgba(156, 174, 184, 0.6)";
-const TOOLTIP_CURSOR_FILL = "rgba(156, 174, 184, 0.08)";
-const BAR_HEIGHT_DESKTOP = 120;
-const BAR_HEIGHT_MOBILE = 100;
-const RECHARTS_ANIM_MS = 800;
-const SAVINGS_LABEL = "3 年間の止血";
-const PROFIT_LABEL = "3 年間の利益創出";
 
 export type ResultDashboardProps = {
   /** calculate() の戻り値（円単位の浮動小数）。 */
@@ -157,215 +133,24 @@ export function ResultDashboard({
   const animatedThreeYearProfit = useCountUp(result.threeYearProfitCreation);
   const animatedTotal = useCountUp(result.totalThreeYearImpact);
 
-  const insourcingPercent = formatPercent(insourcingLevel);
-  const isFullyInsourced = insourcingLevel === 1;
-  const isPartiallyInsourced = insourcingLevel > 0 && insourcingLevel < 1;
-  const chartHeight = isMobile ? BAR_HEIGHT_MOBILE : BAR_HEIGHT_DESKTOP;
-
-  const chartData = useMemo(
-    () => [
-      {
-        label: "3年合計",
-        savings: result.threeYearSavings,
-        profit: result.threeYearProfitCreation,
-      },
-    ],
-    [result.threeYearSavings, result.threeYearProfitCreation],
-  );
-
   return (
-    <section
-      role="region"
-      aria-label="ROI 診断結果"
-      className={cn(
-        "mx-auto w-full max-w-[1024px] space-y-4 sm:space-y-6",
-        className,
-      )}
-    >
-      {headerSlot ? <div>{headerSlot}</div> : null}
-
-      <Card className="py-8 text-center sm:py-12">
-        <p className="text-sm font-medium text-ink/80">
-          3 年間のトータルインパクト
-        </p>
-        <p
-          aria-live="polite"
-          aria-atomic="true"
-          className="mt-3 text-[clamp(2.5rem,6vw,4rem)] font-bold leading-tight text-ink"
-        >
-          {formatManYenCompact(animatedTotal)}
-        </p>
-        <p className="mt-2 text-xs text-ink/60">※ 試算上の最大値</p>
-      </Card>
-
-      <div className="grid grid-cols-1 gap-4 sm:mx-auto sm:max-w-[720px] sm:grid-cols-2 sm:gap-6">
-        <Card>
-          <div className="flex items-center gap-2 text-ink">
-            <PiggyBank aria-hidden="true" className="h-5 w-5 text-accent" />
-            <h3 className="text-sm font-medium">3 年間の止血</h3>
-          </div>
-          <p
-            aria-live="polite"
-            aria-atomic="true"
-            className="mt-3 text-3xl font-bold text-ink"
-          >
-            {formatManYen(animatedSavings)}
-          </p>
-          {isFullyInsourced ? (
-            <p className="mt-2 text-xs text-ink/70">
-              現状、理想形に近い運用のため削減余地は 0 万円
-            </p>
-          ) : isPartiallyInsourced ? (
-            <p className="mt-2 text-xs text-ink/70">
-              既に内製化されている <strong>{insourcingPercent}</strong>{" "}
-              相当分は削減余地から除外済み
-            </p>
-          ) : null}
-        </Card>
-
-        <Card>
-          <div className="flex items-center gap-2 text-ink">
-            <Sparkles aria-hidden="true" className="h-5 w-5 text-accent" />
-            <h3 className="text-sm font-medium">年間の利益創出</h3>
-          </div>
-          <p
-            aria-live="polite"
-            aria-atomic="true"
-            className="mt-3 text-3xl font-bold text-ink"
-          >
-            {formatManYen(animatedAnnualProfit)}
-          </p>
-          <p className="mt-2 text-xs text-ink/70">
-            × 3 年 = {formatManYen(animatedThreeYearProfit)}
-          </p>
-        </Card>
-      </div>
-
-      <Card className="mx-auto w-full max-w-[960px]">
-        <figure className="space-y-3">
-          <figcaption className="sr-only">
-            3 年間の止血と 3 年間の利益創出を積み上げた横棒グラフ。合計が
-            {formatManYen(result.totalThreeYearImpact)}。
-          </figcaption>
-          <ResponsiveContainer width="100%" height={chartHeight}>
-            <BarChart
-              data={chartData}
-              layout="vertical"
-              margin={{ top: 8, right: 24, bottom: 8, left: 16 }}
-            >
-              <XAxis
-                type="number"
-                tickFormatter={(value: number) => formatManYen(value)}
-                stroke={ACCENT_HEX}
-              />
-              <YAxis type="category" dataKey="label" hide />
-              <Tooltip
-                formatter={(value: number) => formatManYen(value)}
-                cursor={{ fill: TOOLTIP_CURSOR_FILL }}
-              />
-              <Legend
-                verticalAlign="bottom"
-                content={() => (
-                  <ul className="flex flex-wrap justify-center gap-x-6 gap-y-2 pt-2 text-xs text-ink">
-                    <li className="flex items-center gap-2">
-                      <PiggyBank
-                        aria-hidden="true"
-                        className="h-4 w-4 text-accent"
-                      />
-                      <span>{SAVINGS_LABEL}</span>
-                      <span className="font-semibold">
-                        {formatManYen(result.threeYearSavings)}
-                      </span>
-                    </li>
-                    <li className="flex items-center gap-2">
-                      <Sparkles
-                        aria-hidden="true"
-                        className="h-4 w-4 text-accent/60"
-                      />
-                      <span>{PROFIT_LABEL}</span>
-                      <span className="font-semibold">
-                        {formatManYen(result.threeYearProfitCreation)}
-                      </span>
-                    </li>
-                  </ul>
-                )}
-              />
-              <Bar
-                dataKey="savings"
-                name={SAVINGS_LABEL}
-                stackId="impact"
-                fill={ACCENT_HEX}
-                radius={[2, 0, 0, 2]}
-                isAnimationActive={!reducedMotion}
-                animationDuration={RECHARTS_ANIM_MS}
-              />
-              <Bar
-                dataKey="profit"
-                name={PROFIT_LABEL}
-                stackId="impact"
-                fill={ACCENT_60}
-                radius={[0, 2, 2, 0]}
-                isAnimationActive={!reducedMotion}
-                animationDuration={RECHARTS_ANIM_MS}
-              />
-            </BarChart>
-          </ResponsiveContainer>
-        </figure>
-
-        {isFullyInsourced ? (
-          <p className="mt-3 text-xs text-ink/70">
-            3 年間の利益創出のみで{" "}
-            {formatManYen(result.threeYearProfitCreation)}{" "}
-            のインパクトが見込めます。
-          </p>
-        ) : null}
-        {result.speedWarning && !headerSlot ? (
-          <p className="mt-3 text-xs text-ink/60">
-            更新待ち期間が 3 ヶ月以上のため、機会損失が継続中の可能性があります。
-          </p>
-        ) : null}
-      </Card>
-
-      <div className="flex flex-col items-center gap-3">
-        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
-          <Button
-            variant="primary"
-            size="lg"
-            type="button"
-            onClick={handleDownloadPdf}
-            disabled={isGeneratingPdf}
-            aria-busy={isGeneratingPdf}
-          >
-            {isGeneratingPdf ? (
-              <>
-                <Loader2
-                  aria-hidden="true"
-                  className="h-4 w-4 animate-spin"
-                />
-                <span>PDF生成中…</span>
-              </>
-            ) : (
-              <span>PDF をダウンロード</span>
-            )}
-          </Button>
-          {onResetRequest ? (
-            <Button
-              variant="secondary"
-              size="lg"
-              type="button"
-              onClick={onResetRequest}
-            >
-              再診断する
-            </Button>
-          ) : null}
-        </div>
-        {pdfError ? (
-          <p role="alert" className="text-sm text-[#B45656]">
-            {pdfError}
-          </p>
-        ) : null}
-      </div>
-
+    <>
+      <DashboardView
+        result={result}
+        insourcingLevel={insourcingLevel}
+        animated={!reducedMotion}
+        animatedSavings={animatedSavings}
+        animatedAnnualProfit={animatedAnnualProfit}
+        animatedThreeYearProfit={animatedThreeYearProfit}
+        animatedTotal={animatedTotal}
+        isMobile={isMobile}
+        onDownloadPdf={handleDownloadPdf}
+        onResetRequest={onResetRequest}
+        isGeneratingPdf={isGeneratingPdf}
+        pdfError={pdfError}
+        headerSlot={headerSlot}
+        className={className}
+      />
       {isGeneratingPdf && generatedAt ? (
         <div
           aria-hidden="true"
@@ -385,6 +170,6 @@ export function ResultDashboard({
           />
         </div>
       ) : null}
-    </section>
+    </>
   );
 }


### PR DESCRIPTION
## 概要
仕様書 `docs/spec/result-dashboard.md §10.2` の「描画層 (`DashboardView`) / 画面コンテナ (`ResultDashboard`) / PDF 用ラッパ (`PdfDashboard`)」3 層分離を本実装化。PR #43（Issue #41）から続いていた「`DashboardView` 抽出は別 Issue として申し送り」（`ResultDashboard.tsx` L9-12）の負債を返済する。

## 詳細
- **`src/components/calculate/DashboardView.tsx`（新規）** — 副作用ゼロの pure component として描画関心を移管。
  - `useState` / `useEffect` / `useRef` / カスタムフック（`useCountUp` / `useMediaQuery`）は一切使用せず、`useMemo` のみ描画派生値最適化用に許可。
  - `useCountUp` × 4 の補間値・`isMobile` / `animated` 等の境界値は props で受け取る pure 設計（テスト容易性確保）。
  - `<Bar>` の `isAnimationActive` は `animated` props 直接参照に変更（仕様書 §10.2 / §11 R10 と整合）。
  - 描画関連定数（`ACCENT_HEX` / `ACCENT_60` / `TOOLTIP_CURSOR_FILL` / `BAR_HEIGHT_*` / `RECHARTS_ANIM_MS` / `SAVINGS_LABEL` / `PROFIT_LABEL`）と凡例静的化方針 / トークン追従コメントは本ファイルに移管。
- **`src/components/calculate/ResultDashboard.tsx`（変更）** — コンテナ責務に純化。
  - JSDoc 冒頭の「暫定構造」「別 Issue として申し送り」記述を削除し、現状の 3 層分離を反映した記述に更新。
  - `recharts` / `lucide-react` / `Card` / `Button` / `cn` / `format` 等の描画関連 import を削除。
  - 本体は `DashboardView` 委譲 + 隠しマウント `<PdfDashboard>` の Fragment 並列構成に置き換え。
  - **コンテナに残置**: `useMediaQuery(REDUCED_MOTION_QUERY)` / `useMediaQuery(MOBILE_QUERY)` / `useState` × 3（`isGeneratingPdf` / `pdfError` / `generatedAt`）/ `useRef` × 2 / `useEffect`（`pdfError` 自動消去）/ `handleDownloadPdf` / `useCountUp` × 4 / 隠しマウント JSX（`pdfDashboardRef` / `generatedAt` / `inputs` 依存のため）。
- **`src/components/calculate/PdfDashboard.tsx`（不変）** — 本 PR では一切編集していない。仕様書 `docs/spec/result-dashboard.md §10.4` および `docs/spec/pdf-report.md §11.4` の方針通り、A4 1 枚最適化と `html2canvas` 互換のため `PdfDashboard` は `DashboardView` を import せず独立 JSX を維持する。

## 参考
- Closes #73
- 仕様書: `docs/spec/result-dashboard.md §10.2`（3 層分離）／§10.4（PDF 独立 JSX 方針）／§11 R1（SSR 境界）／§11 R10（`animated` 規約）／`docs/spec/pdf-report.md §8`（生成フロー）／§11.4（コンテナ責務）
- プラン: `working/plans/issue-73-extract-dashboard-view_260503142643.md`
- 関連 PR: #66 / #70 / #72（`useMediaQuery` 周辺の構造的負債返済の流れに続く `ResultDashboard` 周辺の最終ピース）
- ResultDashboard 公開 API（`ResultDashboardProps`）は不変のため `CalculatePageClient` 側の `next/dynamic({ ssr: false })` 経由経路も変更なし

## 注意事項
- 構造検証:
  - `grep -n "useState\|useEffect\|useRef\|useCountUp\|useMediaQuery" src/components/calculate/DashboardView.tsx` → JSDoc コメント内の言及のみ（実コードでの hook 使用は `useMemo` のみ）
  - `grep -n "暫定構造\|別 Issue として申し送り" src/components/calculate/ResultDashboard.tsx` → 0 件
  - `git diff src/components/calculate/PdfDashboard.tsx` → 空
- 静的検証: `npm run lint` / `npm run typecheck` / `npm run build` ともに exit 0
- 隠しマウント JSX は `<section>` 内から Fragment 直下に微変更となるが、`position: absolute; left: -9999px` で視覚位置はビューポート外固定、`html2canvas` は ref 経由で DOM ノード取得するため挙動変化なし
