### PR TITLE
ci(workflows): lint / typecheck / test / build を GitHub Actions で並列実行 (#49)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+# 設計根拠: Issue #49（GitHub Actions CI 整備 — lint / typecheck / test / build を PR・push で並列実行）
+# 関連 Issue: #48（test ジョブ初版から有効化、ae1949e でマージ済み）
+#             #50（audit は security-audit.yml に集約。本ワークフローでは扱わない）
+# E2E（Playwright）はブラウザインストール時間で 5 分目安を超過するため本ワークフロー対象外。
+# 必要時に別ワークフローで追加検討する。
+name: ci
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+# 同一 PR で連続 push が走った場合に古いジョブを自動キャンセルし、Actions 利用枠を節約する。
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # .nvmrc を Node バージョンの真実の源とする（ローカル `nvm use` と一致）
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run typecheck
+        run: npm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests (Jest)
+        # --ci で snapshot 自動更新を抑止、--runInBand で flake を抑える
+        run: npm test -- --ci --runInBand
+
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run build
+        # next build は output: "export" で out/ を生成
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -49,6 +49,50 @@ npm run typecheck
 npm run lint
 ```
 
+## CI / 品質ゲート
+
+本リポジトリは GitHub Actions で以下 2 ワークフローを運用しています。
+
+| ワークフロー | トリガ | 内容 |
+| --- | --- | --- |
+| `.github/workflows/ci.yml` | `pull_request` / `push`（`main` / `develop`） | `lint` / `typecheck` / `test` / `build` を 4 ジョブで並列実行 |
+| `.github/workflows/security-audit.yml` | `pull_request` / `push`（`main` / `develop`）+ 週次 schedule（毎週月曜 09:00 JST 相当）+ `workflow_dispatch` | `npm audit --audit-level=critical` を実行（high / moderate は到達不能判定済み。`docs/security/jspdf-vulnerabilities.md §6` 参照） |
+
+E2E（Playwright）はブラウザインストールに時間がかかるため CI には含めていません。必要時に別ワークフローでの追加を検討します。
+
+### ローカルで CI 同等の検証を再現
+
+```bash
+npm ci
+npm run lint
+npm run typecheck
+npm test
+npm run build
+```
+
+### branch protection 設定手順（リポジトリ管理者向け）
+
+CI を必須化するには GitHub 側で branch protection を設定してください。
+
+1. GitHub リポジトリの **Settings → Branches → Branch protection rules** で `main` と `develop` をそれぞれ保護対象に追加
+2. **Require a pull request before merging** を有効化
+3. **Require status checks to pass before merging** を有効化し、必須チェックとして以下 4 つを選択（少なくとも 1 度ワークフローが実行されると候補に表示される）
+   - `ci / lint`
+   - `ci / typecheck`
+   - `ci / test`
+   - `ci / build`
+4. `security-audit / audit` は週次運用が主目的のため必須チェックからは除外する（PR 単位の合否と週次運用が混在すると CI 体感が悪化するため）
+5. **Require branches to be up to date before merging** は任意（`develop` のリベース運用方針に応じて選択）
+6. **Restrict who can push to matching branches** を必要に応じて有効化
+
+### CI バッジ（任意）
+
+README 冒頭に CI バッジを置きたい場合は以下を参考に追加してください（本 Issue では追加しません）。
+
+```markdown
+![ci](https://github.com/<owner>/<repo>/actions/workflows/ci.yml/badge.svg?branch=develop)
+```
+
 ## デプロイ
 
 本リポジトリは Cloudflare Pages のダッシュボードで GitHub 連携を構成済みで、push をトリガーに自動デプロイされます。本番 URL は `https://roi.nekonimatatabi.com`（Apex を正規ホストとして運用）。


### PR DESCRIPTION
## 概要

GitHub Actions に `ci.yml` を追加し、PR / push（main / develop）で `lint` / `typecheck` / `test` / `build` を 4 ジョブ並列実行する。Issue #49 の受け入れ条件を満たし、PR 単位の品質ゲートを自動化する。

Closes #49

## 詳細

### 追加ワークフロー: `.github/workflows/ci.yml`

- トリガ: `pull_request` / `push`（`main` / `develop`）
- ジョブ構成: `lint` / `typecheck` / `test` / `build` を **並列**（`needs:` 無し）
- 共通ステップ: `actions/checkout@v4` → `actions/setup-node@v4`（`node-version-file: .nvmrc` + `cache: npm`）→ `npm ci` → 各ジョブ固有コマンド
- ジョブ固有コマンド:
  - `lint`: `npm run lint`
  - `typecheck`: `npm run typecheck`
  - `test`: `npm test -- --ci --runInBand`（Jest 単体）
  - `build`: `npm run build`
- `concurrency: cancel-in-progress: true` で同一 PR の連続 push 時に旧ジョブを自動キャンセル
- 各ジョブに `permissions: { contents: read }`（最小権限、既存 `security-audit.yml` と整合）

### 既存 `security-audit.yml` は変更しない

Issue #49 本文の `--audit-level=high` 指定は #50 確定前のドラフト。`docs/security/jspdf-vulnerabilities.md §6` で `critical` のみブロック運用が確定済みのため、既存ファイル（`--audit-level=critical` + 週次 schedule + `workflow_dispatch` + push/PR）が本 Issue の audit 担当として正となる。重複作成回避のため新規 `audit.yml` は作らない。

### README 追記

「型検証・Lint」節と「デプロイ」節の間に「CI / 品質ゲート」節を新設し、以下を記載:
- 運用中の 2 ワークフロー一覧
- ローカル再現手順（`npm ci && npm run lint && npm run typecheck && npm test && npm run build`）
- branch protection 設定手順（リポジトリ管理者向け）
- CI バッジ追加方法（任意。本 Issue では未追加）

### 設計上のポイント

- **Node バージョンの真実の源**: `.nvmrc`（=20）を `node-version-file` で参照。ローカル `nvm use` と完全一致。`engines.node` との二重管理を避ける
- **E2E（Playwright）は対象外**: ブラウザインストールで 5 分目安を超過するため CI 必須化対象から除外。必要時に別ワークフローで追加検討
- **冒頭コメント**: 既存 `security-audit.yml` の慣習に倣い「設計根拠」「関連 Issue」をコメントで明記

### 受け入れ条件と対応

- [x] PR で lint / typecheck / build が自動実行（受け入れ 1）
- [x] 週次 audit が動作する（既存 `security-audit.yml` で達成済み。受け入れ 3）
- [x] 妥当な時間（5 分以内目安）で完走できる構成（並列化 + キャッシュ。受け入れ 4）
- [x] README に CI / 品質ゲート手順を追記（受け入れ 5）

### マージ後の手動作業（M1）

- [ ] **M1**: リポジトリ管理者が GitHub の **Settings → Branches → Branch protection rules** で `main` / `develop` をそれぞれ保護対象に追加し、必須チェックとして `ci / lint`・`ci / typecheck`・`ci / test`・`ci / build` の 4 つを選択する（少なくとも 1 度ワークフロー実行後に候補に表示される）。`security-audit / audit` は週次運用主目的のため必須チェックには含めない（受け入れ条件 2）。手順は README「branch protection 設定手順」節に記載。

## 参考

- Issue: Closes #49
- 関連: #48（Jest テストスイート、ae1949e でマージ済み → 本 PR で `test` ジョブを初版から有効化）
- 関連: #50（jsPDF 系脆弱性、`docs/security/jspdf-vulnerabilities.md §6` で `critical` のみブロック運用確定済み）
- プラン: `working/plans/issue-49-github-actions-ci-workflow_260503153515.md`

## ローカル検証結果

| コマンド | 結果 |
| --- | --- |
| `npm run lint` | ✅ 成功 |
| `npm run typecheck` | ✅ 成功 |
| `npm test -- --ci --runInBand` | ✅ 11 suites / 120 tests 全 PASS |
| `npm run build` | ✅ 13 ページ静的生成成功 |

## 注意事項

- `package.json` のスクリプトは現行のまま使用（`typecheck` は既に定義済み）。本 PR では変更なし
- E2E（Playwright）は本 CI 対象外。必要時は別ワークフローで `playwright install --with-deps` を含めた構成を検討
- branch protection の必須化は GitHub 側設定のため、マージ後にリポジトリ管理者が M1 を実施する必要あり
