### PR TITLE
feat(deploy): public/_headers で HSTS 初期値とセキュリティヘッダを段階導入 (#51)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,22 @@
+# Cloudflare Pages Response Headers
+#
+# 本ファイルは Next.js の `public/` 配下にあるため、ビルド時に `out/_headers` として
+# 出力ルートへコピーされ、Cloudflare Pages が自動認識して以下のヘッダを応答に付与する。
+# 公式仕様: https://developers.cloudflare.com/pages/configuration/headers/
+#
+# 注意:
+# Cloudflare ダッシュボード側 (SSL/TLS → Edge Certificates → HSTS UI / Transform Rules /
+# Security Headers) では同じヘッダを設定しないこと。本ファイルとの重複設定により
+# `Strict-Transport-Security` などが衝突する。HSTS UI は Disable にしておくこと。
+#
+# HSTS 段階導入:
+# 初期値は max-age=300 (5 分)。1〜2 週間の安定運用を確認した後、別 Issue にて
+# `max-age=31536000; includeSubDomains` へ昇格する PR を作成する。Preload 申請は
+# さらに後段の別 Issue で扱う。
+
+/*
+  Strict-Transport-Security: max-age=300
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Frame-Options: SAMEORIGIN
+  Permissions-Policy: camera=(), microphone=(), geolocation=()


### PR DESCRIPTION
## 概要

Issue #51（本番環境変数・Cloudflare Pages デプロイ最終確認）のうち、コード側で対応する HSTS 段階導入のための `public/_headers` を新規追加します。本番デプロイの応答ヘッダに `Strict-Transport-Security: max-age=300` ほか基本セキュリティヘッダが付与されるようになります。

## 詳細

### コード変更

- **新規** `public/_headers`
  - 全パス (`/*`) に対して以下のレスポンスヘッダを付与
    - `Strict-Transport-Security: max-age=300`（HSTS 段階導入の初期値）
    - `X-Content-Type-Options: nosniff`
    - `Referrer-Policy: strict-origin-when-cross-origin`
    - `X-Frame-Options: SAMEORIGIN`
    - `Permissions-Policy: camera=(), microphone=(), geolocation=()`
  - Cloudflare ダッシュボード側 (HSTS UI / Transform Rules) との重複設定を避ける運用注記をファイル冒頭にコメント
  - 1〜2 週間後に `max-age=31536000; includeSubDomains` へ昇格する運用方針もコメントとして残置
- Next.js は `public/` 配下を `out/` へそのままコピーするため、ビルド時に `out/_headers` として配置される（ローカル `npm run build` で確認済み）

### ユーザー手動作業（マージ後 / 別作業）

本 PR とは別に、Issue #51 の受け入れ条件を満たすため以下の作業をユーザー側で実施してください（Issue にチェックリスト形式で記録予定）。

#### A. Cloudflare ダッシュボード側設定の事前確認

- [ ] Pages プロジェクト設定: Production branch = `main` / Build command = `npm run build` / Build output directory = `out` / `NODE_VERSION=20`
- [ ] 環境変数 (Production スコープ): `NEXT_PUBLIC_SITE_URL = https://roi.nekonimatatabi.com` / `NEXT_PUBLIC_CF_BEACON_TOKEN = <token>`
- [ ] 環境変数 (Preview スコープ): `NEXT_PUBLIC_SITE_URL = https://matatabi-calculator.pages.dev`、`NEXT_PUBLIC_CF_BEACON_TOKEN` は **未設定**
- [ ] DNS: `roi.nekonimatatabi.com` の CNAME (Proxied = ON)
- [ ] SSL/TLS: Full (strict) / Always Use HTTPS = On / Automatic HTTPS Rewrites = On / Minimum TLS 1.2
- [ ] **HSTS UI は Disable**（`public/_headers` 一元管理のため）
- [ ] Custom domains: `roi.nekonimatatabi.com` がアクティブで証明書発行済み

#### B. 本 PR の Preview ビルド検証

- [ ] Cloudflare Pages の Preview ビルドが完走し Preview URL が発行される
- [ ] Preview URL に対する `curl -I` で `Strict-Transport-Security: max-age=300` 等のヘッダが付与される
- [ ] Preview URL のレスポンスに beacon タグ (`static.cloudflareinsights.com/beacon.min.js`) が **含まれない** こと（環境変数スコープ分離の確認）

#### C. 本番デプロイ後の動作確認

- [ ] `https://roi.nekonimatatabi.com/` に HTTPS 接続でき、証明書が有効
- [ ] 主要ページが 200 を返す: `/`, `/calculate`, `/privacy`, `/terms`, `/robots.txt`, `/sitemap.xml`
- [ ] 各レスポンスに `strict-transport-security: max-age=300` が含まれる
- [ ] OG 画像 URL が `https://roi.nekonimatatabi.com/opengraph-image.png?...` の絶対 URL で出力され、200 を返す
- [ ] Cloudflare Web Analytics に PV が計測表示される（5〜30 分以内）
- [ ] 本番 HTML レスポンスに beacon タグが **含まれる**
- [ ] `curl -I http://roi.nekonimatatabi.com/` が `301 → https://...` を返す

#### D. Issue への記録

- [ ] 上記 A〜C の確認結果（チェックリスト + `curl -I` 出力ハイライト）を Issue #51 にコメントとして投稿

## 参考

- Closes #51
- Cloudflare Pages Headers 公式仕様: https://developers.cloudflare.com/pages/configuration/headers/
- README §独自ドメイン運用方針 (HSTS 段階導入の運用方針)

## 注意事項

- 本 PR はコード改修としては `public/_headers` 追加のみ。Cloudflare ダッシュボード側の設定変更（HSTS UI Disable など）は **手動作業**で本 PR には含まれない。
- 本 PR をマージした後、Cloudflare ダッシュボードの **HSTS UI が有効** になっていると `Strict-Transport-Security` ヘッダが衝突する可能性があるため、マージ前にダッシュボード側設定を必ず確認すること。
- 1〜2 週間の安定運用を確認した後、`max-age=31536000; includeSubDomains` への昇格は **別 Issue / 別 PR** で扱う。
- ローカルでの検証 (`npm run lint` / `npm run typecheck` / `npm run build` / `npm test`) はすべて成功し、`out/_headers` がビルド出力に正しく配置されることを確認済み。
