### PR TITLE
feat(a11y): タップターゲット 44px 化と検証マトリクス自動化 (#46)

### DIFF
--- a/e2e/golden-path.spec.ts
+++ b/e2e/golden-path.spec.ts
@@ -27,7 +27,8 @@ test.describe("ROI 診断ゴールデンパス", () => {
     await page.getByLabel(/改修費用/).fill("30");
     await page.getByLabel(/手作業に従事する人数/).fill("5");
     await page.getByRole("radio", { name: "3〜6ヶ月" }).click();
-    await page.getByRole("radio", { name: /一部内製/ }).click();
+    // sm 以上では `shortLabel`（"一部"）に切り替わるため両方をマッチさせる。
+    await page.getByRole("radio", { name: /^一部(内製)?$/ }).click();
     await page.getByRole("button", { name: "診断する" }).click();
 
     // 結果ダッシュボード

--- a/e2e/responsive-matrix.spec.ts
+++ b/e2e/responsive-matrix.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * Issue #46 全ページのモバイル/タブレット最適化検証マトリクス。
+ *
+ * - 仕様: working/plans/issue-46-strict-mobile-tablet-optimization-test_*.md
+ * - 検証観点（自動化可能なもののみ）:
+ *   1. 横スクロール非発生 (`document.documentElement.scrollWidth === clientWidth`)
+ *   2. 主要なインタラクティブ要素のタップターゲット 44×44px 以上 (WCAG 2.5.5 AAA)
+ *   3. ヘッダー sticky / フッター・主要セクションの可視性
+ * - 5 ビューポート: 375 / 390 / 768 / 1024 / 1440
+ * - 実機確認 (iOS Safari ズーム抑止 / PDF ダウンロード) は本スペックの対象外。
+ *   golden-path.spec.ts およびユーザーによる実機確認で別途担保する。
+ *
+ * 実装上の注意:
+ * - `output: "export"` 構成のため `next start` ではなく `serve out -p 3000` 経由。
+ *   `playwright.config.ts` の webServer 設定に従う。
+ * - タップターゲット計測対象は role セレクタで網羅し、`44x44` を境界値として
+ *   満たさない場合に NG として収集。スクリーンショットは Playwright のレポートで参照可能。
+ */
+
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+type ViewportSpec = {
+  label: string;
+  width: number;
+  height: number;
+};
+
+const VIEWPORTS: ReadonlyArray<ViewportSpec> = [
+  { label: "375x812 (iPhone SE / 13 mini)", width: 375, height: 812 },
+  { label: "390x844 (iPhone 14/15)", width: 390, height: 844 },
+  { label: "768x1024 (iPad mini portrait)", width: 768, height: 1024 },
+  { label: "1024x1366 (iPad Pro landscape)", width: 1024, height: 1366 },
+  { label: "1440x900 (Desktop)", width: 1440, height: 900 },
+];
+
+const PUBLIC_PAGES: ReadonlyArray<{ path: string; label: string }> = [
+  { path: "/", label: "ランディング (/)" },
+  { path: "/calculate", label: "ROI 診断 (/calculate)" },
+  { path: "/privacy", label: "プライバシーポリシー" },
+  { path: "/terms", label: "利用規約" },
+  { path: "/contact", label: "お問い合わせ" },
+];
+
+/** WCAG 2.5.5 AAA で要求される最小タップターゲットサイズ (px)。 */
+const MIN_TAP_TARGET = 44;
+
+/**
+ * `<head><meta name="viewport">` が存在し、`width=device-width` を含むことを検証する。
+ * Next.js は `output: "export"` でも `<meta name="viewport" content="width=device-width">` を自動付与する想定。
+ */
+async function expectViewportMeta(page: Page) {
+  const content = await page
+    .locator('meta[name="viewport"]')
+    .first()
+    .getAttribute("content");
+  expect(content, "viewport meta が存在しない").not.toBeNull();
+  expect(content!.toLowerCase()).toContain("width=device-width");
+}
+
+/**
+ * 横スクロール発生をチェック。
+ * scrollbar の影響で 1px 程度ぶれる場合があるため、誤差 1px を許容。
+ */
+async function expectNoHorizontalScroll(page: Page) {
+  const overflow = await page.evaluate(() => {
+    const doc = document.documentElement;
+    return {
+      scrollWidth: doc.scrollWidth,
+      clientWidth: doc.clientWidth,
+      bodyScrollWidth: document.body.scrollWidth,
+    };
+  });
+  // 横スクロールバーや 1px 計算誤差を許容するため 2px の閾値を設定。
+  const diff = overflow.scrollWidth - overflow.clientWidth;
+  expect(
+    diff,
+    `横スクロール発生: scrollWidth=${overflow.scrollWidth}, clientWidth=${overflow.clientWidth}, bodyScrollWidth=${overflow.bodyScrollWidth}`,
+  ).toBeLessThanOrEqual(2);
+}
+
+/**
+ * 与えられた locators の bounding box を計測し、44x44 未満のものを返す。
+ * - `visible=true` のもののみ対象。
+ * - 0px は SSR/CSS 読み込み待ち中の偽陽性が出るためスキップ。
+ * - WCAG 2.5.5 の「インライン例外」を適用: 親が文章 (`<p>` 等) の中の
+ *   `display: inline` リンクは line-height で制約されるため対象外。
+ */
+async function findUndersizedTapTargets(
+  locator: Locator,
+): Promise<Array<{ index: number; width: number; height: number; text: string }>> {
+  const count = await locator.count();
+  const failures: Array<{
+    index: number;
+    width: number;
+    height: number;
+    text: string;
+  }> = [];
+  for (let i = 0; i < count; i++) {
+    const el = locator.nth(i);
+    if (!(await el.isVisible())) continue;
+    const box = await el.boundingBox();
+    if (!box) continue;
+    if (box.width === 0 || box.height === 0) continue;
+    if (box.width < MIN_TAP_TARGET || box.height < MIN_TAP_TARGET) {
+      // WCAG 2.5.5 inline exception: skip plain inline links embedded in body text.
+      const isInline = await el.evaluate((node) => {
+        const cs = window.getComputedStyle(node as Element);
+        return cs.display === "inline";
+      });
+      if (isInline) continue;
+      const text = ((await el.textContent()) ?? "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 60);
+      failures.push({
+        index: i,
+        width: Math.round(box.width),
+        height: Math.round(box.height),
+        text,
+      });
+    }
+  }
+  return failures;
+}
+
+test.describe("Issue #46 5 ビューポート × 全ページ レスポンシブ検証マトリクス", () => {
+  for (const viewport of VIEWPORTS) {
+    test.describe(`viewport: ${viewport.label}`, () => {
+      test.use({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+
+      for (const targetPage of PUBLIC_PAGES) {
+        test(`${targetPage.label} - 横スクロール / タップターゲット / 主要要素`, async ({
+          page,
+        }) => {
+          await page.goto(targetPage.path);
+          // ヘッダーの sticky 配置や Hero など、初期ペイントが完了していることを担保。
+          await page.waitForLoadState("networkidle");
+
+          await expectViewportMeta(page);
+          await expectNoHorizontalScroll(page);
+
+          // 共通レイアウト: Header / Footer の存在を確認。
+          await expect(
+            page.getByRole("banner"),
+            "Header (role=banner) が表示されていない",
+          ).toBeVisible();
+          await expect(
+            page.locator("footer").first(),
+            "Footer が表示されていない",
+          ).toBeVisible();
+
+          // タップターゲット: 全 button / link をまとめて計測。
+          // Next.js 16 が動的注入する Dev Tools ボタン (`data-nextjs-dev-tools-button`)
+          // はフレームワーク責任の UI のため除外する。
+          const tapTargets = page.locator(
+            'a[href], button:not([data-nextjs-dev-tools-button]), [role="button"], [role="radio"], [role="link"], summary',
+          );
+          const undersized = await findUndersizedTapTargets(tapTargets);
+
+          // 失敗時の可読性のためにメッセージ整形（最大 8 件まで表示）。
+          const formatted = undersized
+            .slice(0, 8)
+            .map(
+              (f) =>
+                `  - "${f.text || "(no text)"}" → ${f.width}x${f.height}px`,
+            )
+            .join("\n");
+          expect(
+            undersized,
+            `${targetPage.label} @ ${viewport.label}: ${undersized.length} 件のタップターゲットが 44x44px 未満:\n${formatted}`,
+          ).toEqual([]);
+        });
+      }
+
+      test(`/calculate 結果ダッシュボード - 横スクロール / グラフ / PDF ボタン`, async ({
+        page,
+      }) => {
+        // 結果画面遷移までは golden-path と同じ最小入力。
+        await page.goto("/calculate");
+        await page.waitForLoadState("networkidle");
+
+        await page.getByLabel(/月額ベンダー費用/).fill("50");
+        await page.getByLabel(/改修費用/).fill("30");
+        await page.getByLabel(/手作業に従事する人数/).fill("5");
+        await page.getByRole("radio", { name: "3〜6ヶ月" }).click();
+        // sm 以上では `shortLabel`（"一部"）のみが可視となるため両方をマッチさせる。
+        await page.getByRole("radio", { name: /^一部(内製)?$/ }).click();
+        await page.getByRole("button", { name: "診断する" }).click();
+
+        const resultRegion = page.getByRole("region", { name: "ROI 診断結果" });
+        await expect(resultRegion).toBeVisible();
+
+        await expectNoHorizontalScroll(page);
+
+        // PDF ボタンと再診断ボタンが両方タップしやすいサイズ (44x44 以上) であること。
+        const pdfBtn = page.getByRole("button", { name: /PDF をダウンロード/ });
+        const resetBtn = page.getByRole("button", { name: "再診断する" });
+        for (const [label, btn] of [
+          ["PDF ダウンロード", pdfBtn],
+          ["再診断", resetBtn],
+        ] as const) {
+          await expect(btn).toBeVisible();
+          const box = await btn.boundingBox();
+          expect(box, `${label} ボタンの bounding box が取得できない`).not.toBeNull();
+          expect(
+            box!.height,
+            `${label} ボタンの高さ ${box!.height}px が ${MIN_TAP_TARGET}px 未満`,
+          ).toBeGreaterThanOrEqual(MIN_TAP_TARGET);
+        }
+
+        // ヒーロー数値カードがビューポート内に収まり、かつ可視であること。
+        const heroValue = resultRegion.getByText(/万円/).first();
+        await expect(heroValue).toBeVisible();
+      });
+    });
+  }
+});

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -23,7 +23,7 @@ export default function ContactPage() {
           <p className="mt-2 text-sm leading-relaxed sm:text-base">
             <a
               href="mailto:nekonimatatabi@nekonimatatabi.com"
-              className="text-accent hover:underline"
+              className="inline-flex min-h-11 items-center text-accent hover:underline"
             >
               nekonimatatabi@nekonimatatabi.com
             </a>
@@ -45,7 +45,10 @@ export default function ContactPage() {
 
         <section className="mt-8 border-t border-line/60 pt-6">
           <p className="text-sm">
-            <Link href="/" className="text-accent hover:underline">
+            <Link
+              href="/"
+              className="inline-flex min-h-11 items-center text-accent hover:underline"
+            >
               ← トップページへ戻る
             </Link>
           </p>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -136,7 +136,10 @@ export default function PrivacyPage() {
         <section className="mt-8 border-t border-line/60 pt-6">
           <p className="text-sm text-ink/70">制定日: 2026-05-11</p>
           <p className="mt-3 text-sm">
-            <Link href="/" className="text-accent hover:underline">
+            <Link
+              href="/"
+              className="inline-flex min-h-11 items-center text-accent hover:underline"
+            >
               ← トップページへ戻る
             </Link>
           </p>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -123,7 +123,10 @@ export default function TermsPage() {
         <section className="mt-8 border-t border-line/60 pt-6">
           <p className="text-sm text-ink/70">制定日: 2026-05-11</p>
           <p className="mt-3 text-sm">
-            <Link href="/" className="text-accent hover:underline">
+            <Link
+              href="/"
+              className="inline-flex min-h-11 items-center text-accent hover:underline"
+            >
               ← トップページへ戻る
             </Link>
           </p>

--- a/src/components/calculate/InputForm.tsx
+++ b/src/components/calculate/InputForm.tsx
@@ -150,7 +150,7 @@ const inputBaseClass =
   "aria-[invalid=true]:border-[#B45656]";
 
 const stepperButtonClass =
-  "inline-flex h-11 w-11 items-center justify-center rounded-md border border-line bg-canvas text-lg text-ink " +
+  "inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-line bg-canvas text-lg text-ink " +
   "hover:bg-line/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 " +
   "disabled:cursor-not-allowed disabled:opacity-50";
 

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -20,7 +20,7 @@ export function Footer({ className }: FooterProps) {
             <li>
               <Link
                 href="/privacy"
-                className="hover:text-ink hover:underline focus-visible:outline-none focus-visible:underline"
+                className="inline-flex min-h-11 items-center hover:text-ink hover:underline focus-visible:outline-none focus-visible:underline"
               >
                 プライバシーポリシー
               </Link>
@@ -28,7 +28,7 @@ export function Footer({ className }: FooterProps) {
             <li>
               <Link
                 href="/terms"
-                className="hover:text-ink hover:underline focus-visible:outline-none focus-visible:underline"
+                className="inline-flex min-h-11 items-center hover:text-ink hover:underline focus-visible:outline-none focus-visible:underline"
               >
                 利用規約
               </Link>
@@ -36,7 +36,7 @@ export function Footer({ className }: FooterProps) {
             <li>
               <Link
                 href="/contact"
-                className="hover:text-ink hover:underline focus-visible:outline-none focus-visible:underline"
+                className="inline-flex min-h-11 items-center hover:text-ink hover:underline focus-visible:outline-none focus-visible:underline"
               >
                 お問い合わせ
               </Link>

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -35,7 +35,7 @@ export function Header({ className, cta }: HeaderProps = {}) {
         <Link
           href="/"
           aria-label="またたび計算機 トップページ"
-          className="inline-flex items-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+          className="inline-flex min-h-11 items-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
         >
           <Image
             src="/brand/logo-header.svg"
@@ -53,7 +53,7 @@ export function Header({ className, cta }: HeaderProps = {}) {
             "inline-flex items-center justify-center gap-2 rounded-md font-medium",
             "border border-line bg-canvas text-ink hover:bg-line/30",
             "transition-colors duration-150",
-            "h-9 px-3 text-sm sm:h-10 sm:px-4 sm:text-base",
+            "h-11 px-3 text-sm sm:px-4 sm:text-base",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
           )}
         >

--- a/working/issue-46-verification-result.md
+++ b/working/issue-46-verification-result.md
@@ -1,0 +1,68 @@
+# Issue #46 全ページ モバイル/タブレット最適化 検証マトリクス結果
+
+- 実施日: 2026-05-03
+- ブランチ: `feature/issue-46-strict-mobile-tablet-optimization-test_20260503`
+- 検証ツール: Playwright (chromium / firefox / webkit) × 5 ビューポート
+- 自動検証スクリプト: `e2e/responsive-matrix.spec.ts`
+- ローカル配信: `npm run build && npx serve out -p 3000` (本番同等の静的成果物)
+
+## 1. 検証マトリクス（自動化部分）
+
+各セルは Playwright によるアサーションの結果。`OK` = `pass`、`FIX` = 自動検出された不具合を本 PR で修正済み。
+
+| ページ \ ビューポート | 375x812 | 390x844 | 768x1024 | 1024x1366 | 1440x900 |
+|---|---|---|---|---|---|
+| `/` ランディング | OK | OK | OK | OK | OK |
+| `/calculate` フォーム | OK | OK | OK | OK | OK |
+| `/calculate` 結果ダッシュボード | OK | OK | OK | OK | OK |
+| `/privacy` | OK | OK | OK | OK | OK |
+| `/terms` | OK | OK | OK | OK | OK |
+| `/contact` | OK | OK | OK | OK | OK |
+
+各セルでアサートした観点（`e2e/responsive-matrix.spec.ts` 参照）:
+1. `<meta name="viewport">` が `width=device-width` を含む。
+2. `documentElement.scrollWidth - clientWidth <= 2`（横スクロール非発生、1px 計算誤差を許容）。
+3. Header (`role="banner"`) と Footer の可視性。
+4. 全 `<a href>` / `<button>` / `[role="button"|"radio"|"link"]` / `<summary>` のうち、WCAG 2.5.5 インライン例外（`display: inline`）を除く要素が **44×44px 以上** であること。
+5. `/calculate` 結果ダッシュボードの PDF / 再診断ボタンが 44px 以上、ヒーロー数値が可視。
+
+実行結果: **全 3 ブラウザ × 5 ビューポート × 6 ページ = 90 テスト pass**（chromium / firefox / webkit）。
+
+## 2. 自動検証で検出 → 本 PR で修正した不具合
+
+事前コードレビュー（プラン §1〜3）で懸念されていた点と、新規に検出された点を含む。
+
+| 種別 | 該当ファイル | 修正前 | 修正後 |
+|---|---|---|---|
+| Header CTA タップターゲット | `src/components/ui/Header.tsx` | `h-9 px-3 sm:h-10` (36–40px) | `h-11 px-3 sm:px-4` (44px) |
+| Header ロゴ Link | `src/components/ui/Header.tsx` | ロゴ画像高 28–32px のみ | `inline-flex min-h-11 items-center` |
+| Footer 法務リンク × 3 | `src/components/ui/Footer.tsx` | `text-xs` 12px のテキストリンク | `inline-flex min-h-11 items-center` 付与 |
+| `/contact` メールリンク | `src/app/contact/page.tsx` | テキスト高 16px のみ | `inline-flex min-h-11 items-center` |
+| `/contact` 戻る Link | `src/app/contact/page.tsx` | テキスト高 14px のみ | `inline-flex min-h-11 items-center` |
+| `/privacy` 戻る Link | `src/app/privacy/page.tsx` | テキスト高 14px のみ | `inline-flex min-h-11 items-center` |
+| `/terms` 戻る Link | `src/app/terms/page.tsx` | テキスト高 14px のみ | `inline-flex min-h-11 items-center` |
+| InputForm ステッパー −/＋ | `src/components/calculate/InputForm.tsx` | flex 内で `w-full` input に圧迫され 38×44px | `shrink-0` 追加で `44×44` を担保 |
+
+## 3. 本 PR の対象外（実機確認が必要・受け入れ条件 2）
+
+自動化できない以下の項目は、ユーザーによる実機確認が必要。受け入れ条件 2（iOS Safari / Android Chrome 実機での `/calculate` ゴールデンパス完走）の充足はマージ後の実機確認で担保する。
+
+- **iOS Safari (iPhone 実機)**: `/calculate` で
+  1. ソフトウェアキーボード起動時にズームしないこと（`text-base = 16px` で抑止される設計）
+  2. キーボード表示中にレイアウトが破綻しないこと
+  3. PDF ダウンロード後、Safari ダウンロードバナー → Files への保存ダイアログ
+  4. 生成 PDF (`matatabi-roi-YYYYMMDD-HHmm.pdf`) の A4 1 ページ可読性
+- **Android Chrome (Pixel 等実機)**: 同様の `/calculate` 完走と通知パネルからの PDF 開封
+- **Recharts グラフの軸ラベル可読性 / Legend 折返し**: 768px / 1024px で目視確認
+- **エッジケース**: 「完全内製」選択時の止血カード = 0 円表示 / `clamp(2.5rem,6vw,4rem)` での桁あふれ確認
+
+検証時に追加の不具合が見つかった場合は、サブ Issue を起票して Issue #46 にリンクする運用（プラン §6 受け入れ条件 3）。
+
+## 4. 受け入れ条件カバレッジ
+
+| # | 受け入れ条件 | 充足状況 |
+|---|---|---|
+| 1 | 5 ビューポート × 全ページの検証マトリクスが完了 | **充足**（自動検証 90/90 pass、本ドキュメントが成果物） |
+| 2 | iOS Safari / Android Chrome 実機での `/calculate` ゴールデンパス完走 | **マージ後ユーザー実機確認**（§3 参照） |
+| 3 | 検出した不具合は別 Issue または同 PR で修正済み | **充足**（同 PR で 8 件修正、§2 参照） |
+| 4 | 検証結果を Issue コメントに記録 | **充足予定**（PR マージ後に本ドキュメントを Issue #46 へ転記） |


### PR DESCRIPTION
## 概要

Issue #46 全ページのモバイル/タブレット最適化検証を実施し、検証マトリクスを Playwright で自動化。事前コードレビューおよび実走で検出した WCAG 2.5.5 AAA タップターゲット (44×44px) 違反 8 箇所を同 PR で修正した。

## 詳細

### 自動検証 (新規)

- `e2e/responsive-matrix.spec.ts` を追加し、5 ビューポート (375 / 390 / 768 / 1024 / 1440) × 全公開ページ (`/`, `/calculate`, `/privacy`, `/terms`, `/contact`) で以下を Playwright で自動検証
  1. `<meta name="viewport">` の `width=device-width` 含有
  2. `documentElement.scrollWidth` の横スクロール非発生 (1px 計算誤差を許容)
  3. Header (`role="banner"`) と Footer の可視性
  4. 全 `<a href>` / `<button>` / `[role="..."]` / `<summary>` のうち WCAG 2.5.5 インライン例外を除く要素が **44×44px 以上**
  5. `/calculate` 結果ダッシュボードの PDF / 再診断ボタンとヒーロー数値の可視性
- 結果: chromium / firefox / webkit × 5 ビューポート × 6 ページ = **90 テスト pass** (実行時間 約 32 秒)

### 検出 → 修正した不具合 (8 件)

| 種別 | ファイル | 修正前 → 修正後 |
|---|---|---|
| Header CTA | `Header.tsx` | `h-9 sm:h-10` (36–40px) → `h-11` (44px) |
| Header ロゴ Link | `Header.tsx` | 画像高 28–32px のみ → `inline-flex min-h-11 items-center` |
| Footer 法務 3 リンク | `Footer.tsx` | 12px テキストリンク → `inline-flex min-h-11 items-center` |
| `/contact` メールリンク | `contact/page.tsx` | テキスト高 16px → `inline-flex min-h-11 items-center` |
| `/contact` `/privacy` `/terms` 戻る Link | 各 `page.tsx` | テキスト高 14px → `inline-flex min-h-11 items-center` |
| InputForm ステッパー −/＋ | `InputForm.tsx` | flex 内 input 圧迫で 38×44px → `shrink-0` で 44×44px |

### 既存テストの隠れた不具合修正

- `e2e/golden-path.spec.ts`: `/一部内製/` 正規表現セレクタは ≥ 640px ビューポートで `sm: shortLabel="一部"` に切り替わるため accessible name にマッチせず失敗していた。`/^一部(内製)?$/` に修正

### 検証成果物

- `working/issue-46-verification-result.md`: 検証マトリクス表 + 修正項目 + 受け入れ条件カバレッジ。Issue #46 のコメントへ転記する想定

## 参考

- プラン: `working/plans/issue-46-strict-mobile-tablet-optimization-test_260503163824.md`
- WCAG 2.5.5 (Target Size, AAA): 44×44 CSS px。インライン例外あり
- Closes #46

## 注意事項

### 受け入れ条件カバレッジ

| # | 条件 | 状況 |
|---|---|---|
| 1 | 5 ビューポート × 全ページの検証マトリクス完了 | **充足** (自動検証 90/90 pass) |
| 2 | iOS Safari / Android Chrome 実機 `/calculate` ゴールデンパス完走 | **マージ後ユーザー実機確認**（M1〜M2 参照） |
| 3 | 不具合は別 Issue または同 PR で修正済み | **充足** (本 PR で 8 件修正) |
| 4 | 検証結果を Issue コメントに記録 | **マージ後実施** (M3 参照) |

### マージ後のユーザー手動作業 (M1〜M3)

- **M1.** iPhone (iOS 17+ Safari) 実機で `/calculate` ゴールデンパスを通す:
  1. 月額ベンダー費用入力時にズームしないこと
  2. キーボード表示中にレイアウトが破綻しないこと
  3. PDF ダウンロード後に Files へ保存できること
  4. 生成 PDF (`matatabi-roi-YYYYMMDD-HHmm.pdf`) の A4 1 ページ可読性
- **M2.** Android (Pixel 等) Chrome で `/calculate` 完走と通知パネルからの PDF 開封確認
- **M3.** 検証結果 (`working/issue-46-verification-result.md`) を Issue #46 コメントへ転記し、受け入れ条件 1〜4 をチェック

### 視覚的影響

- Header CTA は 36→44px に高さ増 (Header バー `h-14 sm:h-16` 内に収まる)
- Footer 各リンクは縦方向に 44px 確保 (デスクトップでもやや行が広くなる)
- `/contact` `/privacy` `/terms` の「戻る」リンクと `/contact` のメールリンクは `inline-flex` で 44px 確保 (周辺段落とのリズムが若干変わる)
