### PR TITLE
docs(security): nextjs-15-16-migration-notes.md を移行完了レポートへ更新 (#68)

### DIFF
--- a/docs/security/nextjs-15-16-migration-notes.md
+++ b/docs/security/nextjs-15-16-migration-notes.md
@@ -1,34 +1,38 @@
-# Next.js 15 / 16 移行調査ノート（Issue #53 段階 1 アウトプット）
+# Next.js 15 / 16 移行ノート（Issue #53 / Issue #64 完了レポート）
 
-> ステータス: 調査完了（2026-05-02、`develop` 上の `next@14.2.35` を起点に実施）
-> 関連 Issue: #53（本書の起票元）／ #50（jspdf 系 advisory 判断、`docs/security/jspdf-vulnerabilities.md §6.4` で Next.js 14→16 の別 Issue 化方針を記述）／ #11（Cloudflare Pages 静的エクスポート設定）／ #43（PDF レポート出力、`html2canvas` + `jspdf` 主体方針）
-> 関連プラン: `working/plans/issue-53-nextjs-14-to-16-major-upgrade_260502123644.md`
+> ステータス: 移行完了（2026-05-02、PR #62 / PR #63 / PR #65 にて全段階完了）
+> 関連 Issue: #53（本書の起票元）／ #64（段階 2B 用 Issue、CLOSED 2026-05-02T06:07:53Z）／ #50（jspdf 系 advisory 判断、`docs/security/jspdf-vulnerabilities.md §6.4` で Next.js 14→16 の別 Issue 化方針を記述）／ #11（Cloudflare Pages 静的エクスポート設定）／ #43（PDF レポート出力、`html2canvas` + `jspdf` 主体方針）
+> 関連プラン: `working/plans/issue-53-nextjs-14-to-16-major-upgrade_260502123644.md` ／ `working/plans/issue-64-nextjs-15-to-16-major-upgrade_260502131649.md`
+
+**完了 PR**: PR #62（段階 1, merged 2026-05-02 03:58）／ PR #63（段階 2A, merged 2026-05-02 04:14）／ PR #65（段階 2B + 段階 3, merged 2026-05-02 06:07）
 
 ## 1. 本書の目的
 
-本書は Issue #53「Next.js 14 → 16 メジャー更新と関連 high 脆弱性の解消」の **段階 1（影響範囲調査）** のアウトプットである。後続 PR（段階 2A: v15 移行 / 段階 2B: v16 移行 / 段階 3: 文書最終化）のレビュー時に「**何を確認したか／何を変えないと決めたか**」のエビデンスとして参照する。
+本書は当初 Issue #53 段階 1 の影響範囲調査として作成され、PR #62 / #63 / #65 で全段階完了後に **移行完了レポート** として再構成された。移行時に**事前に予測した影響**と、**実際に発生した差分**（§7 新設）の対比を提供する。
 
-特に `docs/security/jspdf-vulnerabilities.md §6.4.1` には「`next@14.2.35` で `next/font/local` / `@cloudflare/next-on-pages` 連携を前提に運用」との記述があるが、**本リポジトリの実態とは一致しない**（後述 §3）。本書はその差分を明文化し、段階 2A 以降の判断根拠を残す。
+特に `docs/security/jspdf-vulnerabilities.md §6.4.1` には「`next@14.2.35` で `next/font/local` / `@cloudflare/next-on-pages` 連携を前提に運用」との記述があるが、**本リポジトリの実態とは一致しない**（後述 §3）。本書はその差分を明文化し、段階 2A 以降の判断根拠を残す。実際の §3 差分は段階 2B（PR #65）で `docs/security/jspdf-vulnerabilities.md §6.4.1` に履歴注記として反映済み。
 
 ## 2. 本リポジトリの現状（2026-05-02 時点）
 
 ### 2.1 主要バージョン
 
-`package.json`（2026-05-02 時点）より:
+`package.json` 移行前後（2026-05-02 時点）。**起点列＝段階 1 調査時、最終列＝PR #65 マージ後の実測**:
 
-| パッケージ | バージョン | 役割 |
-|---|---|---|
-| `next` | `14.2.35` | フレームワーク本体 |
-| `react` / `react-dom` | `^18` / `^18` | UI ランタイム |
-| `@types/react` / `@types/react-dom` | `^18` / `^18` | 型 |
-| `eslint` | `^8` | リンター |
-| `eslint-config-next` | `14.2.35` | Next 用 lint ルール |
-| `postcss` | `^8` | スタイル処理（推移依存で `next` も依存） |
-| `tailwindcss` | `^3.4.1` | スタイル |
-| `recharts` | `^2.15.4` | グラフ描画（クライアントのみ） |
-| `lucide-react` | `^0.460.0` | アイコン |
-| `html2canvas` | `^1.4.1` | DOM → PNG ラスタライズ |
-| `jspdf` | `^2.5.2` | PDF 生成 |
+| パッケージ | 起点バージョン（段階 1 時） | 最終バージョン（PR #65 後） | 役割 |
+|---|---|---|---|
+| `next` | `14.2.35` | `^16.2.4` | フレームワーク本体 |
+| `react` / `react-dom` | `^18` / `^18` | `^19.0.0` / `^19.0.0` | UI ランタイム |
+| `@types/react` / `@types/react-dom` | `^18` / `^18` | `^19.0.0` / `^19.0.0` | 型 |
+| `eslint` | `^8` | `^9` | リンター |
+| `eslint-config-next` | `14.2.35` | `^16.0.0` | Next 用 lint ルール |
+| `postcss` | `^8` | `^8.5.10` | スタイル処理（推移依存で `next` も依存） |
+| `tailwindcss` | `^3.4.1` | `^3.4.1` | スタイル |
+| `recharts` | `^2.15.4` | `^2.15.4` | グラフ描画（クライアントのみ） |
+| `lucide-react` | `^0.460.0` | `^0.460.0` | アイコン |
+| `html2canvas` | `^1.4.1` | `^1.4.1` | DOM → PNG ラスタライズ |
+| `jspdf` | `^2.5.2` | `^2.5.2` | PDF 生成 |
+
+**実測差分**: `eslint` は段階 1 ノート §4.6 の「8 据え置き」方針から `^9` 必須昇格に変更（§7.1 参照）。`postcss` は `^8` から `^8.5.10` への明示固定が必要（§7.3 参照）。`overrides.next.postcss = "^8.5.10"` を `package.json` に追加（§7.3 参照）。
 
 ### 2.2 配信モード
 
@@ -47,6 +51,8 @@ const nextConfig = {
 - **完全静的エクスポート運用**（`output: "export"`）。`out/` ディレクトリを Cloudflare Pages へ静的アップロードして配信する（Issue #11 / `working/plans/issue-11-cloudflare-pages-setup_260501114546.md`）。
 - 画像は `unoptimized: true` 固定。`next/image` の最適化機能は不使用。
 
+**実測差分（PR #65 後）**: `next.config.mjs` の内容は段階 1 ノートと同一（`output: "export"` / `images.unoptimized: true`）で、Next.js 16 でも変更なし。ただし生成物 `out/` の構造はフラット化された（`out/calculate.html` + `out/calculate/__next.*.txt` 形式へ。詳細 §7.5 / 検証は `out/calculate.html` と `out/calculate/__next._tree.txt` の存在で可能）。
+
 ### 2.3 採用していない Next.js 機能（コード grep で確認）
 
 `grep -rn "<keyword>" src` を 2026-05-02 に実施した結果:
@@ -60,6 +66,8 @@ const nextConfig = {
 | `params:` / `searchParams:` | **0 件** | 動的ルート不使用（すべて静的セグメント） |
 | `"use server"` / `generateStaticParams` | **0 件** | Server Actions / 動的静的生成不使用 |
 | サーバー側 `fetch()` | **0 件**（`src/` 走査） | 外部 API SSR フェッチ不使用 |
+
+**実測差分（PR #65 後）**: 表に挙げた 7 キーワードはいずれも段階 2A / 2B でも 0 件のまま維持された。`@next/codemod` 実行による誤書換は発生せず（§4.2 で予告した検証は OK）。本表は移行後も継続して「該当なし」。
 
 ### 2.4 採用している Next.js 機能と使用箇所
 
@@ -75,7 +83,7 @@ const nextConfig = {
 
 ### 2.5 ESLint 設定
 
-`.eslintrc.json`:
+`.eslintrc.json`（移行前、PR #65 で削除）:
 
 ```json
 {
@@ -90,6 +98,8 @@ const nextConfig = {
 ```
 
 `extends` ベースの旧形式（`.eslintrc.*`）。Flat Config（`eslint.config.*`）には未移行。
+
+**実測差分（PR #65 後）**: `.eslintrc.json` は **削除済み** で `eslint.config.mjs`（Flat Config）に置換された。`next-lint-to-eslint-cli` codemod（`--force` 付き実行）が自動変換し、レガシー設定不可となった（詳細 §7.2）。既存カスタムルール `@typescript-eslint/no-unused-vars`（`argsIgnorePattern` / `varsIgnorePattern`）は `eslint.config.mjs` 内に継承済み。さらに新 ESLint ルール（`react-hooks/set-state-in-effect` / `react-hooks/refs`）が 4 箇所で発火し、`eslint-disable-next-line` 抑制対応となった（§7.4）。
 
 ## 3. Issue / 既存文書の前提と本リポジトリ実態の差分
 
@@ -145,6 +155,8 @@ const nextConfig = {
 - **Flat Config（`eslint.config.*`）への移行は本 Issue のスコープ外**。`.eslintrc.json` 形式を維持する（プラン §8）。
 - 既存ルール（`next/core-web-vitals` / `next/typescript` extends + `@typescript-eslint/no-unused-vars` カスタム）が v15 系の `eslint-config-next` でも互換であることを `npm run lint` で検証。
 
+**実測差分**: 段階 2A の PR #63 では本想定どおり ESLint 8 据え置きで完了したが、段階 2B の PR #65 で `eslint-config-next@^16` の peer 要件により ESLint 9 + Flat Config 必須移行となった。詳細 §7.1 / §7.2。
+
 ### 4.7 Client Router Cache のデフォルト変更
 
 - **影響: なし**（本リポジトリは静的エクスポートで Server Component 階層が極小、かつ全ページが静的生成。Client Router Cache の挙動差は実体験に影響しないと判断）
@@ -194,6 +206,8 @@ const nextConfig = {
 - **影響: 中（v15 → v16 の差分は段階 2A より小さい想定）**
 - 段階 2B では `eslint-config-next: "^15.0.0"` → `"^16.0.0"` のメジャー更新を実施。`.eslintrc.json` の extends 互換性を確認する（プラン §10）。
 
+**実測差分（PR #65）**: `eslint-config-next` を `^15.0.0` → `^16.0.0` に更新した結果、本書 §4.6 の想定（v8 互換維持）が崩れ、`eslint@^9` への昇格と Flat Config への自動移行が同時発生した。詳細 §7.1 / §7.2。
+
 ## 6. React 19 同時更新における依存ライブラリ互換性メモ
 
 段階 2A の `npm install` 時点で確認すべき項目:
@@ -208,44 +222,84 @@ const nextConfig = {
 
 `npm install` で peer dependency 警告が出たライブラリは、段階 2A の PR description にログを貼付して可否を判断する。**警告が継続更新で解消可能なものはマイナーバンプを許容**、破壊的差分が大きい場合は別 Issue 化を検討する。
 
-## 7. 段階 2A / 2B / 3 への申し送り（チェックリスト）
+**実測差分（PR #63 マージ後）**: `recharts@^2.15.4` / `lucide-react@^0.460.0` / `html2canvas@^1.4.1` / `jspdf@^2.5.2` のいずれもバージョン更新を要さず、ビルドおよび実機描画で問題は発生しなかった。`tailwindcss` / `postcss` は §7.3 のとおり `postcss` のみ `^8.5.10` に明示固定が必要となった。
 
-### 段階 2A（v15 移行 PR）
+## 7. 移行後の想定外差分
 
-- [ ] `package.json` の `next` / `react` / `react-dom` / `@types/react` / `@types/react-dom` / `eslint-config-next` を v15 / v19 系へ更新（プラン §3）
-- [ ] `npm install` で `package-lock.json` を再解決（プラン §4）
-- [ ] `npx @next/codemod@latest upgrade latest` を実行し、diff を `git diff` で確認（プラン §5）
-  - 本書 §4.2 / §4.4 のとおり、本リポジトリでは大きな書き換えは発生しない見込み
-- [ ] `src/app/calculate/CalculatePageClient.tsx` の `dynamic({ ssr: false })` がビルドエラーを起こさないこと（本書 §4.5）
-- [ ] `next.config.mjs` / `.eslintrc.json` の互換性確認（プラン §7 / §8）
-- [ ] `npm run lint` / `npm run typecheck` / `npm run build` がグリーン（プラン §9）
-- [ ] Cloudflare Pages preview デプロイで全ページ 200、フォント描画継続、PDF 出力動作
+本節は段階 1 ノート（PR #62）作成時点では予測されておらず、段階 2A / 2B（PR #63 / #65）の実装中に判明した差分を時系列＋分類別に記録する。後続の Next.js メジャー更新（v17 想定）時の参照用。
 
-### 段階 2B（v16 移行 PR、段階 2A マージ後）
+### 7.1 ESLint 8 → 9 への必要昇格
 
-- [ ] `next` を `^16.2.4` 以降に更新（プラン §10）
-- [ ] `eslint-config-next` を `^16.0.0` に更新（プラン §10）
-- [ ] `npx @next/codemod@latest upgrade latest` を再実行（プラン §12）
-- [ ] `npm audit --json` で `next` / `glob` / `eslint-config-next` / `@next/eslint-plugin-next` / `postcss` の advisory が **0 件**（受け入れ条件 1）
-- [ ] PDF 生成の実機回帰: `docs/spec/pdf-report.md §3.1 / §11.2 / §11.3` の実装契約遵守（プラン §14）
+PR #65 で `eslint-config-next@^16.0.0` を導入した結果、当該パッケージが `eslint@>=9.0.0` を peer 必須としたため、段階 1 ノート §4.6 の「ESLint 8 据え置き、Flat Config 別 Issue 化」方針は維持不可能となり、`eslint@^8` → `^9` のメジャー昇格を同 PR で実施した。`package.json` L40 で `eslint: "^9"` 確定。
 
-### 段階 3（文書更新）
+### 7.2 `.eslintrc.json` → `eslint.config.mjs`（Flat Config）への移行
 
-- [ ] `docs/security/jspdf-vulnerabilities.md §6.4` を「移行完了」ステータスに更新、Issue #53 番号を §6.4.2 に追記（プラン §15、受け入れ条件 6）
-- [ ] §6.4.1 に本書 §3 の差分注記を追加（`next/font/local` 不使用 / `@cloudflare/next-on-pages` 未導入）
-- [ ] `README.md` の Next.js バージョン表記を更新（プラン §16）
-- [ ] `.claude/issue-order.md` フェーズ 1 表記に「後に Issue #53 で `next@16` へ更新」注記を追加（プラン §17）
-- [ ] `.claude/ROI診断アプリ「またたび計算機」開発・設計ドキュメント一式.md` の Framework 表記を更新（プラン §18）
-- [ ] `.github/workflows/security-audit.yml` は据え置き（プラン §19）
+`npx @next/codemod@canary next-lint-to-eslint-cli .` を `--force` 付きで実行し、`.eslintrc.json` 削除 / `eslint.config.mjs` 新規生成。`next@16` ではレガシー `.eslintrc.*` が動作不可。codemod 生成の未使用 import（`path`, `fileURLToPath`）は手動除去。既存カスタムルールは Flat Config 内に継承済み（`/Users/YS/development/matatabi-calculator/eslint.config.mjs` 参照）。
 
-## 8. 関連ファイル
+### 7.3 `postcss` `overrides` の必要性
+
+段階 1 ノート §2.1 では `next@16` への更新で `postcss` advisory が自動解消すると想定していたが、`next@16.2.4` がネスト依存に `postcss@8.4.31`（vulnerable）を pin していたため、`package.json` 末尾に `overrides.next.postcss = "^8.5.10"`（L49〜L53）を追加して全ネスト依存を強制更新する必要があった。直接依存の `postcss` も `^8` → `^8.5.10` に同時バンプ（L44）。`docs/security/jspdf-vulnerabilities.md §6.3` の overrides 不採用方針は dompurify / jspdf 互換性破壊リスクが理由で、postcss の semver マイナー差分（8.4 → 8.5）には適用されないと判断（PR #65 description の「プランからの逸脱」参照）。
+
+### 7.4 新 ESLint ルール（`react-hooks/set-state-in-effect` / `react-hooks/refs`）の発火
+
+Next.js 16 同梱の `eslint-config-next@^16` で新規追加された 2 ルールが既存コードで 4 箇所発火。発火箇所は `src/components/calculate/ResultDashboard.tsx`（`useReducedMotion` / `useIsMobile` の `setX(mql.matches)` 同期、`PdfDashboard` への `generatedAt={generatedAtRef.current ?? new Date()}` 渡し）と `src/hooks/useCountUp.ts`（`setReducedMotion(mql.matches)`）。本 PR では `eslint-disable-next-line` で抑制し理由コメントを併記。`useSyncExternalStore` への正攻法リファクタは別 Issue 候補として切り出し（本 Issue #68 とは別 Issue）。
+
+### 7.5 Next.js 16 静的エクスポート構造の変更
+
+v15 までの `out/calculate/index.html` 形式から、v16 では `out/calculate.html`（フラット）+ `out/calculate/__next._full.txt` / `__next._head.txt` / `__next._index.txt` / `__next._tree.txt` / `__next.calculate.__PAGE__.txt` / `__next.calculate.txt`（Turbopack メタデータ）の併存形式に変更（実測値、`/Users/YS/development/matatabi-calculator/out/calculate/` 直下）。`/calculate` URL の到達性は Cloudflare Pages の auto-routing で維持され、Issue #11 の静的アップロード運用と非互換にはならない。本書 §4.5 / §5.5 の検証想定（「`out/calculate/index.html` のレンダリング結果が変わらない」）は文言更新が必要だが、機能要件としては満たされた。
+
+## 8. 段階別最終結果（PR 番号 / マージ日）
+
+段階 1 時点ではチェックリスト形式だったが、全段階完了後の本改訂では実施結果として記録する。
+
+### 8.1 段階 1（PR #62, merged 2026-05-02 03:58）— 移行調査ノート策定
+
+- [x] `docs/security/nextjs-15-16-migration-notes.md` 初版作成（本書）
+
+### 8.2 段階 2A（PR #63, merged 2026-05-02 04:14）— next@15.5.15 / React 19 採用
+
+- [x] `package.json` の `next` / `react` / `react-dom` / `@types/react` / `@types/react-dom` / `eslint-config-next` を v15 / v19 系へ更新
+- [x] `npm install` で `package-lock.json` を再解決
+- [x] `npx @next/codemod@latest upgrade latest` を実行し、diff を `git diff` で確認
+  - 本書 §4.2 / §4.4 のとおり、本リポジトリでは大きな書き換えは発生しなかった
+- [x] `src/app/calculate/CalculatePageClient.tsx` の `dynamic({ ssr: false })` がビルドエラーを起こさないことを確認（本書 §4.5）
+- [x] `next.config.mjs` / `.eslintrc.json` の互換性確認
+- [x] `npm run lint` / `npm run typecheck` / `npm run build` グリーン
+- [x] Cloudflare Pages preview デプロイで全ページ 200、フォント描画継続、PDF 出力動作
+
+### 8.3 段階 2B（PR #65, merged 2026-05-02 06:07）— next@16.2.4 / eslint-config-next@^16 / eslint@^9 / Flat Config / postcss overrides
+
+- [x] `next` を `^16.2.4` 以降に更新
+- [x] `eslint-config-next` を `^16.0.0` に更新（→ ESLint 9 必須昇格、§7.1 参照）
+- [x] `.eslintrc.json` → `eslint.config.mjs`（Flat Config）への自動移行（§7.2 参照）
+- [x] `package.json` `overrides.next.postcss = "^8.5.10"` 追加（§7.3 参照）
+- [x] 新 ESLint ルール（`react-hooks/set-state-in-effect` / `react-hooks/refs`）の 4 箇所発火を `eslint-disable-next-line` で抑制（§7.4 参照）
+- [x] `npx @next/codemod@latest upgrade latest` を再実行
+- [x] `npm audit --json` で `next` / `glob` / `eslint-config-next` / `@next/eslint-plugin-next` / `postcss` の advisory が **0 件**（受け入れ条件 1）
+- [x] 静的エクスポート出力構造が `out/calculate.html` + `out/calculate/__next.*.txt` 形式へ変更されたことを確認（§7.5 参照）
+- [x] PDF 生成の実機回帰: `docs/spec/pdf-report.md §3.1 / §11.2 / §11.3` の実装契約遵守
+
+### 8.4 段階 3（PR #65 同梱, merged 2026-05-02 06:07）— 文書更新
+
+- [x] `docs/security/jspdf-vulnerabilities.md §6.4` を「移行完了」ステータスに更新、Issue #53 番号を §6.4.2 に追記
+- [x] §6.4.1 に本書 §3 の差分注記を追加（`next/font/local` 不使用 / `@cloudflare/next-on-pages` 未導入）
+- [x] `README.md` の Next.js バージョン表記を更新
+- [x] `.claude/issue-order.md` フェーズ 1 表記に「後に Issue #53 で `next@16` へ更新」注記を追加
+- [x] `.claude/ROI診断アプリ「またたび計算機」開発・設計ドキュメント一式.md` の Framework 表記を更新
+- [x] `docs/brand/README.md` 更新
+- [x] `.github/workflows/security-audit.yml` は据え置き
+
+## 9. 関連ファイル
 
 - `working/plans/issue-53-nextjs-14-to-16-major-upgrade_260502123644.md` — 本書を生成する元プラン
+- `working/plans/issue-64-nextjs-15-to-16-major-upgrade_260502131649.md` — PR #65 のプラン
 - `docs/security/jspdf-vulnerabilities.md` — §6.4 / §6.4.1 / §6.4.2（Issue #53 の動機）
 - `docs/spec/pdf-report.md` — PDF 生成の実装契約（§3.1 / §11.2 / §11.3、段階 2B 検証で参照）
 - `next.config.mjs` — `output: "export"` / `images.unoptimized: true`
 - `package.json` — 移行対象パッケージ
+- `package.json` `overrides` セクション（L49〜L53） — `postcss` 強制更新の根拠
 - `.eslintrc.json` — `eslint-config-next` extends
+- `eslint.config.mjs` — Flat Config 実装（PR #65 で `.eslintrc.json` から置換）
 - `src/app/layout.tsx` — `next/font/google` 使用箇所
 - `src/app/calculate/CalculatePageClient.tsx` — `next/dynamic({ ssr: false })` 使用箇所
 - `src/app/{robots,sitemap,manifest}.ts` — `MetadataRoute` 使用箇所


### PR DESCRIPTION
## 概要

Issue #68 対応。`docs/security/nextjs-15-16-migration-notes.md` を Issue #53 段階 1 の影響範囲調査ノートから、Issue #53 / Issue #64 全段階完了後の **移行完了レポート** へ刷新する単一ファイル文書更新。コードおよび設定への影響なし。

## 詳細

### 主な変更

- **ヘッダー / ステータス（L1〜L5 周辺）**: H1 を「Next.js 15 / 16 移行ノート（Issue #53 / Issue #64 完了レポート）」に、ステータスを「移行完了（2026-05-02、PR #62 / PR #63 / PR #65 にて全段階完了）」に変更。関連 Issue に `#64`、関連プランに `issue-64-nextjs-15-to-16-major-upgrade_*.md` を追加し、引用ブロック直後に「完了 PR」サマリ行を追加。
- **§1「本書の目的」**: 段階 1 アウトプット表現を「移行完了レポート」表現に書き換え、§7 新設・§3 差分の `jspdf-vulnerabilities.md §6.4.1` への反映済みフラグを明記。
- **§2.1 主要バージョン**: 表に「最終バージョン（PR #65 後）」列を新設し、`package.json` 実測値（`next@^16.2.4` / `react@^19.0.0` / `eslint@^9` / `eslint-config-next@^16.0.0` / `postcss@^8.5.10`）を反映。表直下に `eslint` の v9 必須昇格・`postcss` overrides 追加への参照を追記。
- **§2.2 配信モード / §2.3 採用していない機能 / §2.5 ESLint 設定**: 各節末尾に「実測差分（PR #65 後）」段落を追加。`out/` フラット化（`out/calculate.html` + `out/calculate/__next.*.txt`）、§2.3 の 7 キーワード 0 件維持、`.eslintrc.json` 削除と Flat Config 置換を記録。
- **§4.6 / §5.6 / §6 のインライン実測差分**: 段階 1 ノートが誤想定していた箇所（ESLint v8 互換維持、`eslint-config-next` v15→v16 の差分想定、依存ライブラリ更新不要想定）に PR #63 / PR #65 の実測値で補正コメントを挿入。
- **§7「移行後の想定外差分」を新設**:
  - §7.1 ESLint 8 → 9 への必要昇格
  - §7.2 `.eslintrc.json` → `eslint.config.mjs`（Flat Config）への移行
  - §7.3 `postcss` `overrides` の必要性
  - §7.4 新 ESLint ルール（`react-hooks/set-state-in-effect` / `react-hooks/refs`）の発火と `eslint-disable-next-line` 抑制
  - §7.5 Next.js 16 静的エクスポート構造の変更（`out/calculate.html` フラット化）
- **旧 §7 → §8「段階別最終結果」**: 申し送りチェックリストを実施結果へ改編。§8.1（PR #62）／ §8.2（PR #63、`next@15.5.15` / React 19）／ §8.3（PR #65、`next@16.2.4` / Flat Config / postcss overrides）／ §8.4（PR #65 同梱、文書更新）の 4 段階それぞれのマージ日と完了形チェックリストを記録。
- **旧 §8 → §9「関連ファイル」**: `working/plans/issue-64-...md`、`eslint.config.mjs`、`package.json` `overrides` セクションへの参照を追加。

### 受け入れ条件チェック

- [x] **AC1**: 冒頭に「移行完了」ステータス注記が追加される（L3 ステータス行 + L7 完了 PR サマリ）
- [x] **AC2**: §2.x / §2.5 / §4.6 / §5.6 / §6 が「想定 → 実測差分」フォーマットに更新される
- [x] **AC3**: §7「移行後の想定外差分」が新設され、5 件（ESLint 9 昇格 / Flat Config 移行 / postcss overrides / 新 lint ルール / 静的エクスポート構造変更）が記録される
- [x] **AC4**: §8 配下に段階 1（PR #62）／ 2A（PR #63）／ 2B（PR #65）／ 3（PR #65 同梱）の最終結果（PR 番号 + マージ日）が記録される
- [x] **AC5**: 関連 Issue #53 / #64 との整合（CLOSED 済み Issue として参照、本書 §3 の章番号は維持され `jspdf-vulnerabilities.md §6.4.1` L208 の相互参照と整合）

### 検証結果

- 構造整合性: `grep -n '^## '` で §1〜§9 が重複なく順に出力されることを確認
- §3 章番号維持: `grep -n '^## 3\.'` で L104 に存在を確認（`jspdf-vulnerabilities.md` 側との相互参照崩れなし）
- §7.1〜§7.5 / §8.1〜§8.4 の見出し全件存在を確認
- 単一ファイル変更: `git diff --cached --stat` で `docs/security/nextjs-15-16-migration-notes.md` 1 件のみ（+99 / -45）

純粋な文書更新のため lint / typecheck / build の追加実行は不要（プラン §検証方法 8）。

## 参考

Closes #68

- 一次プラン: `working/plans/issue-68-update-nextjs-migration-notes-as-final_260503194359.md`
- 関連 Issue: #53（移行親 Issue）／ #64（段階 2B 用 Issue、CLOSED 2026-05-02）／ #50（jspdf 系 advisory）／ #11（Cloudflare Pages 静的エクスポート）／ #43（PDF レポート）
- 関連 PR: PR #62（段階 1）／ PR #63（段階 2A）／ PR #65（段階 2B + 段階 3）

## 注意事項

- コードおよび設定への影響は **無し**。`package.json` / `eslint.config.mjs` / `next.config.mjs` / `src/**` への変更ゼロ。
- §3 章番号は維持しているため、`docs/security/jspdf-vulnerabilities.md §6.4.1` L208 の `nextjs-15-16-migration-notes.md §3` 参照は引き続き有効（編集不要）。
- §7.4 の `react-hooks/set-state-in-effect` 発火 4 箇所の `useSyncExternalStore` 化（正攻法リファクタ）は本 Issue #68 とは別 Issue 候補としてスコープ外。
