### PR TITLE
docs(deploy): README の HSTS 記述を本格運用値に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ README 冒頭に CI バッジを置きたい場合は以下を参考に追加し
 
 - 正規ホスト: Apex (`roi.nekonimatatabi.com`)。将来 `www.roi.nekonimatatabi.com` を併設する場合は Cloudflare の Redirect Rule で 301 を返す方針（現時点では併設なし）
 - SSL/TLS モード: **Full (strict)**、Always Use HTTPS = On、Automatic HTTPS Rewrites = On、Minimum TLS Version = 1.2
-- HSTS: 段階導入。初期 `max-age=300`（5 分）で開始し、1〜2 週間の安定運用後に `max-age=31536000` + `includeSubDomains` へ引き上げる（Preload 申請は別 Issue で扱う）
+- HSTS: 本格運用値 `max-age=31536000; includeSubDomains`。Preload 申請は別 Issue で扱う。
 - 詳細な Cloudflare ダッシュボード設定値は Issue #12 のコメントを参照
 
 ## ドキュメント


### PR DESCRIPTION
## 概要

README.md の「独自ドメイン運用方針」節の HSTS 記述を、段階導入（初期 `max-age=300`）から本格運用値（`max-age=31536000; includeSubDomains`）へ更新する。

## 変更内容

- **変更前**: `HSTS: 段階導入。初期 \`max-age=300\`（5 分）で開始し、1〜2 週間の安定運用後に \`max-age=31536000\` + \`includeSubDomains\` へ引き上げる（Preload 申請は別 Issue で扱う）`
- **変更後**: `HSTS: 本格運用値 \`max-age=31536000; includeSubDomains\`。Preload 申請は別 Issue で扱う。`

## ⚠️ マージ条件

**本 PR は Cloudflare ダッシュボード側の HSTS 値更新と同時にマージすること。**
README とダッシュボードの実際の設定が乖離しないよう、以下の作業完了後にマージしてください。

1. Cloudflare ダッシュボード SSL/TLS → Edge Certificates → HSTS で `max-age=31536000`、Apply HSTS to subdomains (includeSubDomains) = On に更新済みであること
2. `curl -sI https://roi.nekonimatatabi.com/ | grep -i strict-transport-security` で `max-age=31536000` が返ることを確認済みであること

**Cloudflare 側の更新が未完の状態で本 PR をマージしないこと。**

## 関連

- 追跡 Issue: #92
- 元の運用方針: Issue #12, PR #30
- HSTS Preload 申請は別 Issue で扱う（#92 本文参照）

---
_Generated by [Claude Code](https://claude.ai/code/session_012LavZFdjWrBYxz2y3HKPtJ)_